### PR TITLE
Cedar image for docker

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -3,7 +3,7 @@ MAINTAINER Fabio Kung <fabio@heroku.com>
 
 ADD bin/cedar.sh /tmp/build.sh
 RUN /tmp/build.sh
-RUN ["bash", "-c", "mkdir", "-p", "/{app,tmp,proc,dev,var,var/log,var/tmp,home/group_home}"]
+RUN bash -c 'mkdir -p /{app,tmp,proc,dev,var,var/log,var/tmp,home/group_home}'
 RUN chmod 755 /home/group_home
 RUN echo "export PS1='\\[\\033[01;34m\\]\\w\\[\\033[00m\\] \\[\\033[01;32m\\]$ \\[\\033[00m\\]'" > /etc/bash.bashrc
 RUN rm -f /tmp/cedar.sh

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,6 @@
+FROM heroku/ubuntu:lucid
+MAINTAINER Fabio Kung <fabio@heroku.com>
+
+ADD bin/cedar.sh /tmp/build.sh
+RUN /tmp/build.sh
+RUN rm -f /tmp/cedar.sh

--- a/Dockerfile
+++ b/Dockerfile
@@ -3,4 +3,7 @@ MAINTAINER Fabio Kung <fabio@heroku.com>
 
 ADD bin/cedar.sh /tmp/build.sh
 RUN /tmp/build.sh
+RUN ["bash", "-c", "mkdir", "-p", "/{app,tmp,proc,dev,var,var/log,var/tmp,home/group_home}"]
+RUN chmod 755 /home/group_home
+RUN echo "export PS1='\\[\\033[01;34m\\]\\w\\[\\033[00m\\] \\[\\033[01;32m\\]$ \\[\\033[00m\\]'" > /etc/bash.bashrc
 RUN rm -f /tmp/cedar.sh

--- a/Readme.md
+++ b/Readme.md
@@ -65,3 +65,27 @@ debuild -us -uc
 ```
 
 The package will be in the top dir `../`.
+
+
+Docker images
+-------------
+
+The `Dockerfile` provided here can be used to build a cedar base image to be
+used in Docker:
+
+```
+docker build -t heroku/cedar .
+```
+
+Heroku base images (`heroku/ubuntu:lucid`) are built using the
+`contrib/mkimage-debootstrap.sh` script, included in the docker project:
+
+```
+git clone https://github.com/dotcloud/docker.git
+cd docker/contrib
+# edit mkimage-debootstrap and uncomment/add the following lines:
+# rm etc/dpkg/dpkg.cfg.d/02apt-speedup
+# rm etc/apt/apt.conf.d/no-languages
+./mkimage-debootstrap.sh -i iproute,iputils-ping,gpgv heroku/ubuntu lucid http://archive.ubuntu.com/ubuntu
+```
+


### PR DESCRIPTION
Dockerfile + instructions on how to generate cedar docker images. I'm trying to have them at https://index.docker.io/u/heroku. A preview of images generated by these changes can be seen here: https://index.docker.io/u/fabiokung.

Once we have this Dockerfile merged, we will also be able to setup [Trusted Builds](http://docs.docker.io/en/latest/use/workingwithrepository/#trusted-builds).