### PR TITLE
Allow build-stack to set release name

### DIFF
--- a/Readme.md
+++ b/Readme.md
@@ -8,7 +8,7 @@ The provided `bin/cedar.sh` is the basis of a cedar stack image.
     vagrant up
     vagrant ssh
 
-    sudo /vagrant/bin/build-stack 2.0.0 /vagrant/bin/cedar.sh
+    sudo /vagrant/bin/build-stack 2.0.0 /vagrant/bin/cedar.sh lucid
     -----> Starting build
     -----> Installing build tools
            Hit http://us.archive.ubuntu.com lucid Release.gpg

--- a/bin/build-stack
+++ b/bin/build-stack
@@ -8,6 +8,7 @@ mkdir -p /tmp/log
 
   VERSION=$1
   SCRIPT=$2
+  RELEASE=${3-'trusty'}
   MNT=/tmp/cedar64-$VERSION-build
 
   [ $UID = 0 ]     || abort fatal: must be called with sudo
@@ -30,7 +31,7 @@ mkdir -p /tmp/log
   display Bootstrapping build env $MNT
   (
     mkdir -p $MNT
-    debootstrap --variant=minbase trusty $MNT
+    debootstrap --variant=minbase $RELEASE $MNT
   ) | indent
 
   display Mounting host in build env


### PR DESCRIPTION
When trying to run `sudo /vagrant/bin/build-stack 2.0.0 /vagrant/bin/cedar.sh` it breaks because of the hardcoded suite in `debootstrap --variant=minbase trusty $MNT`. I updated `build-stack` to accept a third argument to specify the `debootstrap` suite. If left empty, it will just default to `trusty`.