### PR TITLE
Change list terminator

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -49,7 +49,7 @@ RUN apt-get install -y --force-yes \
     telnet \
     zip \
     zlib1g-dev \
-    #
+    -
 
 RUN apt-cache search language-pack \
     | cut -d ' ' -f 1 \


### PR DESCRIPTION
This resolves #9.

The purpose of having the list terminator is so that adding packages to the bottom of the list produces a patch that affects that entry only.
