### PR TITLE
add an empty /sys to stack images

### DIFF
--- a/bin/capture-stack
+++ b/bin/capture-stack
@@ -44,7 +44,7 @@ LOG=/tmp/log/$(basename $0).log
   display Modifying image directories and files
   (
     # etc/heroku is a mountpoint for runtime dyno information
-    for d in app tmp proc dev var var/log var/tmp home/group_home etc/heroku; do
+    for d in app tmp proc sys dev var var/log var/tmp home/group_home etc/heroku; do
       mkdir -p $IMG_MNT/$d
     done
     chmod 755 $IMG_MNT/home/group_home

--- a/bin/capture-stack
+++ b/bin/capture-stack
@@ -44,6 +44,7 @@ LOG=/tmp/log/$(basename $0).log
   display Modifying image directories and files
   (
     # etc/heroku is a mountpoint for runtime dyno information
+    # sys is there so users of the stack can mount a sysfs on it (/sys is the default location)
     for d in app tmp proc sys dev var var/log var/tmp home/group_home etc/heroku; do
       mkdir -p $IMG_MNT/$d
     done


### PR DESCRIPTION
This allows users of read-only base stack images to mount a `sysfs` inside their containers.