### PR TITLE
Remove workaround for ImageTragick.

### DIFF
--- a/bin/cedar-14.sh
+++ b/bin/cedar-14.sh
@@ -142,21 +142,6 @@ apt-cache search language-pack \
     | grep -v '\-base$' \
     | xargs apt-get install -y --force-yes --no-install-recommends
 
-# Workaround for CVE-2016–3714 until new ImageMagick packages come out.
-cat > /etc/ImageMagick/policy.xml <<'IMAGEMAGICK_POLICY'
-<policymap>
-  <policy domain="coder" rights="none" pattern="EPHEMERAL" />
-  <policy domain="coder" rights="none" pattern="URL" />
-  <policy domain="coder" rights="none" pattern="HTTPS" />
-  <policy domain="coder" rights="none" pattern="MVG" />
-  <policy domain="coder" rights="none" pattern="MSL" />
-  <policy domain="coder" rights="none" pattern="TEXT" />
-  <policy domain="coder" rights="none" pattern="SHOW" />
-  <policy domain="coder" rights="none" pattern="WIN" />
-  <policy domain="coder" rights="none" pattern="PLT" />
-</policymap>
-IMAGEMAGICK_POLICY
-
 cd /
 rm -rf /var/cache/apt/archives/*.deb
 rm -rf /root/*


### PR DESCRIPTION
The upstream debs now contain their own feature manifest, so we no longer need to provide our own to protect our customers.