### PR TITLE
Fix the indentation of the 'installed versions' log output

### DIFF
--- a/bin/cedar-14.sh
+++ b/bin/cedar-14.sh
@@ -174,7 +174,7 @@ echo -e "\nInstalled versions:"
   ruby -v
   gem -v
   python -V
-) | sed -u "s/^/  /"
+) 2>&1 | sed -u "s/^/  /"
 
 echo -e "\nSuccess!"
 exit 0

--- a/bin/cedar.sh
+++ b/bin/cedar.sh
@@ -177,7 +177,7 @@ echo -e "\nInstalled versions:"
   ruby -v
   gem -v
   python -V
-) | sed -u "s/^/  /"
+) 2>&1 | sed -u "s/^/  /"
 
 echo -e "\nSuccess!"
 exit 0


### PR DESCRIPTION
This fixes the indentation of the Python version output during the build script, since it's not on stdout.

Before:
```
Installed versions:
  git version 1.9.1
  ruby 1.9.3p484 (2013-11-22 revision 43786) [x86_64-linux]
  1.8.23
Python 2.7.6
```

After:
```
Installed versions:
  git version 1.9.1
  ruby 1.9.3p484 (2013-11-22 revision 43786) [x86_64-linux]
  1.8.23
  Python 2.7.6
```