### PR TITLE
Generate a tar/gzip'ed stack image as well

### DIFF
--- a/bin/capture-stack
+++ b/bin/capture-stack
@@ -73,8 +73,7 @@ EOF
   ) | indent
 
   display Creating tgz image and MD5
-  tar -zcpf $TGZ -C $IMG_MNT ./
-  md5sum $TGZ | cut -d ' ' -f 1 | tr -d '\n' | tee $TGZ.md5 | indent
+  tar -zcp -C $IMG_MNT ./ | tee $TGZ | md5sum | cut -d ' ' -f 1 | tr -d '\n' | tee $TGZ.md5 | indent
 
   display Unmounting image
   umount $IMG_MNT

--- a/bin/capture-stack
+++ b/bin/capture-stack
@@ -8,6 +8,7 @@ LOG=/tmp/log/$(basename $0).log
   VERSION=$1
   MNT=/tmp/cedar64-$VERSION-build
   IMG=/tmp/cedar64-$VERSION.img
+  TGZ=/tmp/cedar64-$VERSION.tar.gz
   IMG_MNT=/tmp/cedar64-$VERSION
 
   [ $UID = 0 ]  || abort fatal: must be called with sudo
@@ -70,6 +71,10 @@ EOF
 EOF
     chmod 644 $IMG_MNT/home/group_home/.gitconfig
   ) | indent
+
+  display Creating tgz image and MD5
+  tar -zcpf $TGZ -C $IMG_MNT ./
+  md5sum $TGZ | cut -d ' ' -f 1 | tr -d '\n' | tee $TGZ.md5 | indent
 
   display Unmounting image
   umount $IMG_MNT


### PR DESCRIPTION
There are some situations where not having to loop mount a whole image is advantageous, so also generate a straight up tar & gzipped version of the images content before unmounting the created image.
### TODO
- [ ] Use something better than md5 (sha256?)
