### PR TITLE
Separate heroku-16 and heroku-dev-16 images

### DIFF
--- a/heroku-16/bin/heroku-16.sh
+++ b/heroku-16/bin/heroku-16.sh
@@ -85,59 +85,42 @@ PGDG_ACCC4CF8
 apt-get update
 apt-get upgrade -y --force-yes
 apt-get install -y --force-yes \
-    autoconf \
     bind9-host \
-    bison \
-    build-essential \
+    bzip2 \
     coreutils \
     curl \
-    daemontools \
     dnsutils \
     ed \
     git \
-    imagemagick \
     iputils-tracepath \
     language-pack-en \
-    libbz2-dev \
-    libcurl4-openssl-dev \
-    libevent-dev \
-    libev-dev \
-    libgcrypt20-dev \
-    libglib2.0-dev \
-    libgnutls-dev \
-    libidn11-dev \
-    libjpeg-dev \
-    libkrb5-dev \
-    libldap2-dev \
-    libmagickwand-dev \
-    libmysqlclient-dev \
-    libncurses5-dev \
-    libpq-dev \
-    libpq5 \
-    librdkafka-dev \
-    libreadline-dev \
-    libssl-dev \
-    libuv-dev \
-    libxml2-dev \
-    libxslt-dev \
-    libyaml-dev \
     netcat-openbsd \
     openssh-client \
-    openssh-server \
     postgresql-client-9.5 \
-    postgresql-server-dev-9.5 \
     python \
-    python-dev \
     ruby \
-    ruby-dev \
     socat \
     stunnel \
     syslinux \
     tar \
     telnet \
     zip \
-    zlib1g-dev \
-    #
+    libcurl3 \
+    libev4 \
+    libevent-2.0-5 \
+    libgnutls-openssl27 \
+    libgnutlsxx28 \
+    libmysqlclient20 \
+    libuv1 \
+    libxslt1.1 \
+    libmemcached11 \
+    libmcrypt4 \
+    
+# avoid ghostscript
+apt-get install -y --force-yes --no-install-recommends \
+    imagemagick \
+    libmagickcore-6.q16-2-extra \
+    netpbm \
 
 # locales
 #apt-cache search language-pack \

--- a/heroku-dev-16/Dockerfile
+++ b/heroku-dev-16/Dockerfile
@@ -1,0 +1,4 @@
+FROM heroku/heroku:16
+COPY ./bin/heroku-dev-16.sh /tmp/build.sh
+RUN LC_ALL=C DEBIAN_FRONTEND=noninteractive /tmp/build.sh \
+  && rm -rf /var/lib/apt/lists/*

--- a/heroku-dev-16/bin/heroku-dev-16.sh
+++ b/heroku-dev-16/bin/heroku-dev-16.sh
@@ -1,0 +1,73 @@
+#!/bin/bash
+
+exec 2>&1
+set -e
+set -x
+
+apt-get update
+apt-get install -y --force-yes \
+    autoconf \
+    bison \
+    build-essential \
+    libbind-dev \
+    libbsd-dev \
+    libbz2-dev \
+    libcairo2-dev \
+    libcurl4-openssl-dev \
+    libevent-dev \
+    libev-dev \
+    libffi-dev \
+    libgcrypt20-dev \
+    libglib2.0-dev \
+    libgnutls-dev \
+    libicu-dev \
+    libidn11-dev \
+    libjpeg-dev \
+    libkrb5-dev \
+    libldap2-dev \
+    libmagickwand-dev \
+    libmcrypt-dev \
+    libmemcached-dev \
+    libmysqlclient-dev \
+    libncurses5-dev \
+    libpam0g-dev \
+    libpq-dev \
+    libreadline-dev \
+    libssl-dev \
+    libuv1-dev \
+    libxml2-dev \
+    libxslt-dev \
+    libyaml-dev \
+    postgresql-server-dev-9.5 \
+    python-dev \
+    ruby-dev \
+    zlib1g-dev \
+
+cd /
+rm -rf /var/cache/apt/archives/*.deb
+rm -rf /root/*
+rm -rf /tmp/*
+
+# remove SUID and SGID flags from all binaries
+function pruned_find() {
+  find / -type d \( -name dev -o -name proc \) -prune -o $@ -print
+}
+
+pruned_find -perm /u+s | xargs -r chmod u-s
+pruned_find -perm /g+s | xargs -r chmod g-s
+
+# remove non-root ownership of files
+#chown root:root /var/lib/libuuid; true
+
+# display build summary
+set +x
+echo -e "\nRemaining suspicious security bits:"
+(
+  pruned_find ! -user root
+  pruned_find -perm /u+s
+  pruned_find -perm /g+s
+  pruned_find -perm /+t
+) | sed -u "s/^/  /"
+
+echo -e "\nSuccess!"
+exit 0


### PR DESCRIPTION
For now. There are a few packages we still may want to adjust, but this is the biggest chunk so far.

The regular runtime image now has significant space savings over the `-dev` one:

```
After this operation, 408 MB of additional disk space will be used.
```