### PR TITLE
Add docker build wrapper script and Travis configuration

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,0 +1,14 @@
+sudo: required
+dist: trusty
+language: shell
+services:
+  - docker
+env:
+  - STACK=heroku-16
+  - STACK=cedar-14
+script:
+  - bin/docker-build.sh $STACK
+matrix:
+  allow_failures:
+    # Remove once #58 fixed.
+    - env: STACK=cedar-14

--- a/bin/docker-build.sh
+++ b/bin/docker-build.sh
@@ -1,0 +1,31 @@
+#!/bin/bash
+
+set -euo pipefail
+
+cd "$(dirname "$(dirname "${BASH_SOURCE[0]}")")"
+. bin/stack-helpers.sh
+
+[ $# -eq 1 ] || abort usage: $(basename "${BASH_SOURCE[0]}") STACK
+
+STACK="${1%/}"
+IMAGE_TAG="heroku/${STACK/-/:}"
+DOCKERFILE_DIR="$STACK"
+
+# Remove this when cedar-14 is moved from the repository root to ./cedar-14/.
+[[ "$STACK" = "cedar-14" ]] && DOCKERFILE_DIR="."
+
+[[ -d "$DOCKERFILE_DIR" ]] || abort fatal: stack "$STACK" not found
+
+display "Building $STACK main image"
+docker build --pull --tag "$IMAGE_TAG" "$DOCKERFILE_DIR" | indent
+
+if [[ "$STACK" != "cedar-14" ]]; then
+    display "Building $STACK build-time image"
+    # The --pull option is not used to ensure the build image variant is based on the
+    # main stack image built above, rather than the one last published to Docker Hub.
+    docker build --tag "${IMAGE_TAG}-build" "${DOCKERFILE_DIR}-build" | indent
+fi
+
+display "Size breakdown..."
+docker images --format "table {{.Repository}}:{{.Tag}}\t{{.Size}}" \
+    | grep -E "(ubuntu|heroku)" | tac | indent


### PR DESCRIPTION
To allow for easy testing of the Docker builds both on Travis and locally. Example Travis run (on my fork):
https://travis-ci.org/edmorley/stack-images/builds/248952759

The script also outputs the resultant image sizes ([example](https://travis-ci.org/edmorley/stack-images/jobs/248952761#L3525)), to show the size impact of eg adding additional libraries.

Prior to this merging Travis will need enabling on this repo, via:
https://travis-ci.org/profile