### PR TITLE
Add missing universe entries to cedar-14's APT sources list

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -8,7 +8,3 @@ env:
   - STACK=cedar-14
 script:
   - bin/docker-build.sh $STACK
-matrix:
-  allow_failures:
-    # Remove once #58 fixed.
-    - env: STACK=cedar-14

--- a/bin/cedar-14.sh
+++ b/bin/cedar-14.sh
@@ -5,10 +5,9 @@ set -e
 set -x
 
 cat > /etc/apt/sources.list <<EOF
-deb http://archive.ubuntu.com/ubuntu trusty main
-deb http://archive.ubuntu.com/ubuntu trusty-security main
-deb http://archive.ubuntu.com/ubuntu trusty-updates main
-deb http://archive.ubuntu.com/ubuntu trusty universe
+deb http://archive.ubuntu.com/ubuntu trusty main universe
+deb http://archive.ubuntu.com/ubuntu trusty-security main universe
+deb http://archive.ubuntu.com/ubuntu trusty-updates main universe
 
 deb http://apt.postgresql.org/pub/repos/apt/ trusty-pgdg main
 EOF

--- a/bin/cedar-14.sh
+++ b/bin/cedar-14.sh
@@ -5,9 +5,9 @@ set -e
 set -x
 
 cat > /etc/apt/sources.list <<EOF
-deb http://archive.ubuntu.com/ubuntu trusty main universe
-deb http://archive.ubuntu.com/ubuntu trusty-security main universe
-deb http://archive.ubuntu.com/ubuntu trusty-updates main universe
+deb http://archive.ubuntu.com/ubuntu/ trusty main universe
+deb http://archive.ubuntu.com/ubuntu/ trusty-security main universe
+deb http://archive.ubuntu.com/ubuntu/ trusty-updates main universe
 
 deb http://apt.postgresql.org/pub/repos/apt/ trusty-pgdg main
 EOF

--- a/heroku-16/bin/heroku-16.sh
+++ b/heroku-16/bin/heroku-16.sh
@@ -5,9 +5,9 @@ set -e
 set -x
 
 cat > /etc/apt/sources.list <<EOF
-deb http://archive.ubuntu.com/ubuntu xenial main universe
-deb http://archive.ubuntu.com/ubuntu xenial-security main universe
-deb http://archive.ubuntu.com/ubuntu xenial-updates main universe
+deb http://archive.ubuntu.com/ubuntu/ xenial main universe
+deb http://archive.ubuntu.com/ubuntu/ xenial-security main universe
+deb http://archive.ubuntu.com/ubuntu/ xenial-updates main universe
 
 deb http://apt.postgresql.org/pub/repos/apt/ xenial-pgdg main
 EOF


### PR DESCRIPTION
Previously `universe` was only specified for the `trusty` repository and not also `trusty-{security,updates}`, which causes version mismatches for packages whose dependencies cross the stable/security/updates repository boundaries.

The sources list now matches that in the `ubuntu-debootstrap:14.04` image (aside from the postgresql addition).

Fixes #58.

This PR also adds trailing slashes to the APT source URLs to stop HTTP 301s, and for parity with the upstream Ubuntu images.

Note: I'll rebase this once #59 lands so it can be seen to have fixed the cedar-14 build.