### PR TITLE
Make install-stack create /mnt/stacks earlier

### DIFF
--- a/bin/install-stack
+++ b/bin/install-stack
@@ -11,6 +11,8 @@ LOG=/tmp/log/$(basename $0).log
   [ $UID = 0 ] || abort fatal: must be called with sudo
 
   display Starting install at $(date)
+  mkdir -p $MNT
+
   if [[ -f $IMG_GZ ]]; then
     display Gunzipping image $IMG_GZ
     gunzip -c $IMG_GZ > $MNT.img
@@ -20,6 +22,5 @@ LOG=/tmp/log/$(basename $0).log
   fi
 
   display Mounting image $MNT
-  mkdir -p $MNT
   mount -o loop,noatime,nodiratime,ro $MNT.img $MNT
 ) 2>&1 | tee $LOG


### PR DESCRIPTION
To ensure the directory exists prior to saving the image within it.

Fixes #62.