### PR TITLE
Depend explicitly on locales package

### DIFF
--- a/cedar-14/bin/cedar-14.sh
+++ b/cedar-14/bin/cedar-14.sh
@@ -102,6 +102,7 @@ apt-get install -y --force-yes \
     libev-dev \
     libevent-dev \
     libglib2.0-dev \
+    libicu52 \
     libjpeg-dev \
     libmagickwand-dev \
     libmysqlclient-dev \

--- a/cedar-14/bin/cedar-14.sh
+++ b/cedar-14/bin/cedar-14.sh
@@ -115,6 +115,7 @@ apt-get install -y --force-yes \
     libuv-dev \
     libxml2-dev \
     libxslt-dev \
+    locales \
     netcat-openbsd \
     openjdk-7-jdk \
     openjdk-7-jre-headless \

--- a/heroku-16/bin/heroku-16.sh
+++ b/heroku-16/bin/heroku-16.sh
@@ -111,6 +111,7 @@ apt-get install -y --force-yes \
     librabbitmq4 \
     libuv1 \
     libxslt1.1 \
+    locales \
     make \
     netcat-openbsd \
     openssh-client \


### PR DESCRIPTION
This package is no longer included in the upstream image (see docker-library/official-images#2856).

We still have it in our images as a dependency of the language-pack-en package but we should rather make that dependency explicit. (The language pack could change to only provided pre-compiled locales.)