### PR TITLE
Depend explicitly on libgconf-2-4 package

### DIFF
--- a/cedar-14/bin/cedar-14.sh
+++ b/cedar-14/bin/cedar-14.sh
@@ -101,6 +101,7 @@ apt-get install -y --force-yes \
     libcurl4-openssl-dev \
     libev-dev \
     libevent-dev \
+    libgconf-2-4 \
     libglib2.0-dev \
     libicu52 \
     libjpeg-dev \


### PR DESCRIPTION
[heroku-buildpack-google-chrome](https://github.com/heroku/heroku-buildpack-google-chrome) expects this package:

https://github.com/heroku/heroku-buildpack-google-chrome/blob/03127f6d1c8bc7f8793a01f943ca448e4f91ec52/bin/compile#L63-L73