### PR TITLE
Avoid constructing URL for MD5 checksum file

### DIFF
--- a/cedar-14/bin/cedar-14.sh
+++ b/cedar-14/bin/cedar-14.sh
@@ -173,7 +173,7 @@ echo -e "\nRemaining suspicious security bits:"
   pruned_find -perm /u+s
   pruned_find -perm /g+s
   pruned_find -perm /+t
-) | sed -u "s/^/  /"
+) | sed "s/^/  /"
 
 echo -e "\nInstalled versions:"
 (
@@ -181,7 +181,7 @@ echo -e "\nInstalled versions:"
   ruby -v
   gem -v
   python -V
-) 2>&1 | sed -u "s/^/  /"
+) 2>&1 | sed "s/^/  /"
 
 echo -e "\nSuccess!"
 exit 0

--- a/cedar-14/bin/push-stack
+++ b/cedar-14/bin/push-stack
@@ -46,6 +46,5 @@ EOF
   s3cmd -c $S3CFG --progress --acl-public put $IMG_SHA256 s3://$S3_IMG_SHA256
 
   echo "http://s3.amazonaws.com/$S3_IMG_GZ" | indent
-  echo "http://s3.amazonaws.com/$S3_IMG_MD5" | indent
   echo "http://s3.amazonaws.com/$S3_IMG_SHA256" | indent
 ) 2>&1 | tee $LOG

--- a/cedar-14/bin/stack-helpers.sh
+++ b/cedar-14/bin/stack-helpers.sh
@@ -13,5 +13,5 @@ function abort() {
 }
 
 function indent() {
-  sed -u "s/^/       /"
+  sed "s/^/       /"
 }

--- a/docker-build.sh
+++ b/docker-build.sh
@@ -34,6 +34,9 @@ if [[ "$STACK" != "cedar-14" ]]; then
     write_package_list "$BUILD_IMAGE_TAG" "$BUILD_DOCKERFILE_DIR"
 fi
 
+# MacOS protip: if this step fails, run `brew install coreutils` and follow the
+# directions in the output to update your PATH and MANPATH. `tac` is part of
+# that package.
 display "Size breakdown..."
 docker images --format "table {{.Repository}}:{{.Tag}}\t{{.Size}}" \
     | grep -E "(ubuntu|heroku)" | tac | indent


### PR DESCRIPTION
`$S3_IMG_MD5` is not set so this already doesn't work and should have been removed in #50.