### PR TITLE
Install apt-utils.

### DIFF
--- a/heroku-16-build/installed-packages.txt
+++ b/heroku-16-build/installed-packages.txt
@@ -1,6 +1,7 @@
 # List of packages present in the final image. Regenerate using docker-build.sh
 adduser
 apt
+apt-utils
 autoconf
 automake
 autotools-dev

--- a/heroku-16/bin/heroku-16.sh
+++ b/heroku-16/bin/heroku-16.sh
@@ -84,6 +84,7 @@ PGDG_ACCC4CF8
 apt-get update
 apt-get upgrade -y --force-yes
 apt-get install -y --force-yes \
+    apt-utils \
     bind9-host \
     bzip2 \
     coreutils \

--- a/heroku-16/installed-packages.txt
+++ b/heroku-16/installed-packages.txt
@@ -1,6 +1,7 @@
 # List of packages present in the final image. Regenerate using docker-build.sh
 adduser
 apt
+apt-utils
 base-files
 base-passwd
 bash
@@ -61,6 +62,7 @@ language-pack-en-base
 less
 libacl1
 libapparmor1
+libapt-inst2.0
 libapt-pkg5.0
 libasn1-8-heimdal
 libatm1


### PR DESCRIPTION
This fixes some issues where package installation can fail with

    debconf: delaying package configuration, since apt-utils is not installed

(This issue cannot be reliably addressed by installing apt-utils at the same time as other packages.)

The additional footprint of this package is minimal, and it appears to be required for noninteractive installation of other packages.