### PR TITLE
add libsodium

### DIFF
--- a/heroku-16-build/bin/heroku-16-build.sh
+++ b/heroku-16-build/bin/heroku-16-build.sh
@@ -54,6 +54,7 @@ apt-get install -y --force-yes \
     librtmp-dev \
     libselinux1-dev \
     libsemanage1-dev \
+    libsodium-dev \
     libssl-dev \
     libsystemd-dev \
     libudev-dev \

--- a/heroku-16-build/installed-packages.txt
+++ b/heroku-16-build/installed-packages.txt
@@ -381,6 +381,8 @@ libsigsegv2
 libsm-dev
 libsm6
 libsmartcols1
+libsodium-dev
+libsodium18
 libsqlite3-0
 libss2
 libssl-dev

--- a/heroku-16/bin/heroku-16.sh
+++ b/heroku-16/bin/heroku-16.sh
@@ -109,6 +109,7 @@ apt-get install -y --force-yes \
     libmcrypt4 \
     libmemcached11 \
     libmysqlclient20 \
+    libsodium18 \
     librabbitmq4 \
     libuv1 \
     libxslt1.1 \

--- a/heroku-16/installed-packages.txt
+++ b/heroku-16/installed-packages.txt
@@ -220,6 +220,7 @@ libsemanage-common
 libsemanage1
 libsepol1
 libsmartcols1
+libsodium18
 libsqlite3-0
 libss2
 libssl1.0.0


### PR DESCRIPTION
PHP 7.2+ ships with new crypto features that require this library, which is a well maintained, up to date fork of libnacl that provides modern networking and crypto primitives

This adds [libsodium18](https://packages.ubuntu.com/xenial/libsodium18) to the `heroku-16` image and [libsodium-dev](https://packages.ubuntu.com/xenial/libsodium-dev) to `heroku-16-build`.