### PR TITLE
Add GNU gettext

### DIFF
--- a/heroku-16-build/bin/heroku-16-build.sh
+++ b/heroku-16-build/bin/heroku-16-build.sh
@@ -9,6 +9,7 @@ apt-get install -y --force-yes \
     autoconf \
     bison \
     build-essential \
+    gettext \
     libacl1-dev \
     libapparmor-dev \
     libapt-pkg-dev \

--- a/heroku-16-build/installed-packages.txt
+++ b/heroku-16-build/installed-packages.txt
@@ -52,7 +52,6 @@ gcc-6-base
 geoip-bin
 geoip-database
 gettext
-libasprintf-dev
 ghostscript
 gir1.2-freedesktop
 gir1.2-gdkpixbuf-2.0

--- a/heroku-16-build/installed-packages.txt
+++ b/heroku-16-build/installed-packages.txt
@@ -49,9 +49,10 @@ gcc
 gcc-5
 gcc-5-base
 gcc-6-base
-gettext
 geoip-bin
 geoip-database
+gettext
+libasprintf-dev
 ghostscript
 gir1.2-freedesktop
 gir1.2-gdkpixbuf-2.0
@@ -97,6 +98,8 @@ libapt-pkg-dev
 libapt-pkg5.0
 libasan2
 libasn1-8-heimdal
+libasprintf-dev
+libasprintf0v5
 libatk1.0-0
 libatk1.0-data
 libatm1
@@ -192,6 +195,8 @@ libgdk-pixbuf2.0-common
 libgdk-pixbuf2.0-dev
 libgeoip-dev
 libgeoip1
+libgettextpo-dev
+libgettextpo0
 libgirepository-1.0-1
 libglib2.0-0
 libglib2.0-bin
@@ -408,6 +413,7 @@ libtsan0
 libubsan0
 libudev-dev
 libudev1
+libunistring0
 libusb-0.1-4
 libustr-1.0-1
 libustr-dev

--- a/heroku-16-build/installed-packages.txt
+++ b/heroku-16-build/installed-packages.txt
@@ -49,6 +49,7 @@ gcc
 gcc-5
 gcc-5-base
 gcc-6-base
+gettext
 geoip-bin
 geoip-database
 ghostscript

--- a/heroku-16-build/installed-packages.txt
+++ b/heroku-16-build/installed-packages.txt
@@ -52,6 +52,7 @@ gcc-6-base
 geoip-bin
 geoip-database
 gettext
+gettext-base
 ghostscript
 gir1.2-freedesktop
 gir1.2-gdkpixbuf-2.0


### PR DESCRIPTION
[gettext][gettext] is commonly used in various frameworks and
programming languages to provide support for i18n. Such as
* Python/Django
* Ruby/translation
* Python/flask-babel
* ... may more.

I does not make sense to have it available in side the runtime dyno, but during build time, it is helpful to have the package available to compile gettext `po` files (to `mo`).

There are already some buildpacks doing that, but since this is a GNU tool, it makes sense to have it in the main image.

[gettext]: https://www.gnu.org/software/gettext/