### PR TITLE
Add packages to the script that are present in debootstrap but not in the Ubuntu 14 docker image.

### DIFF
--- a/cedar-14/bin/cedar-14.sh
+++ b/cedar-14/bin/cedar-14.sh
@@ -85,15 +85,19 @@ apt-get update
 apt-get upgrade -y --force-yes
 apt-get install -y --force-yes \
     autoconf \
+    acl \
     bind9-host \
     bison \
     build-essential \
     coreutils \
     curl \
     daemontools \
+    dbus \
     dnsutils \
     ed \
+    fuse \
     git \
+    groff-base \
     gvfs \
     imagemagick \
     iputils-tracepath \
@@ -121,6 +125,7 @@ apt-get install -y --force-yes \
     libxslt-dev \
     locales \
     netcat-openbsd \
+    ntfs-3g \
     openjdk-7-jdk \
     openjdk-7-jre-headless \
     openssh-client \
@@ -138,6 +143,7 @@ apt-get install -y --force-yes \
     tar \
     telnet \
     tzdata \
+    xkb-data \
     zip \
     zlib1g-dev \
     #


### PR DESCRIPTION
This makes it possible to extract the docker image to build stack images, and will allow us to decommission the Vagrant-based build tool.