### PR TITLE
Remove Vagrant related entries from .{docker,git}ignore

### DIFF
--- a/cedar-14/.dockerignore
+++ b/cedar-14/.dockerignore
@@ -1,4 +1,1 @@
-.vagrant/
-tmp/
 installed-packages.txt
-Vagrantfile

--- a/cedar-14/.gitignore
+++ b/cedar-14/.gitignore
@@ -1,2 +1,0 @@
-.vagrant
-.s3cfg


### PR DESCRIPTION
These are unused after #94.