### PR TITLE
Add apt-transport-https package

### DIFF
--- a/cedar-14/bin/cedar-14.sh
+++ b/cedar-14/bin/cedar-14.sh
@@ -86,6 +86,7 @@ apt-get upgrade -y --force-yes
 apt-get install -y --force-yes \
     autoconf \
     acl \
+    apt-transport-https \
     bind9-host \
     bison \
     build-essential \

--- a/cedar-14/installed-packages.txt
+++ b/cedar-14/installed-packages.txt
@@ -2,6 +2,7 @@
 acl
 adduser
 apt
+apt-transport-https
 at-spi2-core
 autoconf
 automake

--- a/heroku-16-build/bin/heroku-16-build.sh
+++ b/heroku-16-build/bin/heroku-16-build.sh
@@ -6,7 +6,6 @@ set -x
 
 apt-get update
 apt-get install -y --force-yes \
-    apt-transport-https \
     autoconf \
     bison \
     build-essential \

--- a/heroku-16-build/bin/heroku-16-build.sh
+++ b/heroku-16-build/bin/heroku-16-build.sh
@@ -6,6 +6,7 @@ set -x
 
 apt-get update
 apt-get install -y --force-yes \
+    apt-transport-https \
     autoconf \
     bison \
     build-essential \

--- a/heroku-16-build/installed-packages.txt
+++ b/heroku-16-build/installed-packages.txt
@@ -1,6 +1,7 @@
 # List of packages present in the final image. Regenerate using docker-build.sh
 adduser
 apt
+apt-transport-https
 apt-utils
 autoconf
 automake

--- a/heroku-16/bin/heroku-16.sh
+++ b/heroku-16/bin/heroku-16.sh
@@ -85,6 +85,7 @@ apt-get update
 apt-get upgrade -y --force-yes
 apt-get install -y --force-yes \
     apt-utils \
+    apt-transport-https \
     bind9-host \
     bzip2 \
     coreutils \

--- a/heroku-16/installed-packages.txt
+++ b/heroku-16/installed-packages.txt
@@ -1,6 +1,7 @@
 # List of packages present in the final image. Regenerate using docker-build.sh
 adduser
 apt
+apt-transport-https
 apt-utils
 base-files
 base-passwd


### PR DESCRIPTION
Allows us to support using TLS hosted apt repositories in the stack image and any apt buildpacks (https://github.com/heroku/heroku-buildpack-apt/issues/26)