### PR TITLE
Build only master branch

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -3,6 +3,9 @@ dist: trusty
 language: shell
 services:
   - docker
+branches:
+  only:
+    - master
 env:
   - STACK=heroku-16
   - STACK=cedar-14


### PR DESCRIPTION
Right now, Travis CI starts a build for each pull request and one for each push. That's a lot of extra builds. We can't disable pull requests because that will break contributions. We can't disable pushes entirely because that will then not check master.