### PR TITLE
Sort stacks alphabetically

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -7,8 +7,8 @@ branches:
   only:
     - master
 env:
-  - STACK=heroku-16
   - STACK=cedar-14
+  - STACK=heroku-16
 script:
   - ./docker-build.sh $STACK
   - |


### PR DESCRIPTION
Sorting these alphabetically makes Travis CI start building Cedar-14 first which is great because it's the slowest one. That means that if more queue capacity come available halfway through the build, it will likely not affect the overall completion time whereas it will if the slowest build is queued.