### PR TITLE
Downgrade JDK package

### DIFF
--- a/heroku-16/bin/heroku-16.sh
+++ b/heroku-16/bin/heroku-16.sh
@@ -136,7 +136,7 @@ apt-get install -y --no-install-recommends ca-certificates-java openjdk-8-jre-he
 apt-get remove -y ca-certificates-java
 apt-get -y --purge autoremove
 apt-get purge -y openjdk-8-jre-headless
-stat /etc/ssl/certs/java/cacerts
+test "$(file -b /etc/ssl/certs/java/cacerts)" = "Java KeyStore"
 
 cd /
 rm -rf /root/*

--- a/heroku-18/bin/heroku-18.sh
+++ b/heroku-18/bin/heroku-18.sh
@@ -150,11 +150,11 @@ apt-get install -y --no-install-recommends \
     zip \
 
 # install the JDK for certificates, then remove it
-apt-get install -y --no-install-recommends ca-certificates-java openjdk-11-jre-headless
+apt-get install -y --no-install-recommends ca-certificates-java openjdk-8-jre-headless
 apt-get remove -y ca-certificates-java
 apt-get -y --purge autoremove
-apt-get purge -y openjdk-11-jre-headless
-stat /etc/ssl/certs/java/cacerts
+apt-get purge -y openjdk-8-jre-headless
+test "$(file -b /etc/ssl/certs/java/cacerts)" = "Java KeyStore"
 
 cd /
 rm -rf /root/*


### PR DESCRIPTION
For some reason, [the "openjdk-11-jre-headless" package](https://packages.ubuntu.com/bionic/openjdk-11-jre-headless) will produce a certificate bundle that Java can't read.

This can be verified locally with Docker. Use the following Dockerfile:

```dockerfile
FROM ubuntu:18.04
RUN apt-get update && apt-get install -y --no-install-recommends openjdk-11-jre-headless
CMD ["keytool", "-list", "-keystore", "/etc/ssl/certs/java/cacerts"]
```

Build the image and run it:

    Warning: use -cacerts option to access cacerts keystore
    Enter keystore password:  
    *****************  WARNING WARNING WARNING  *****************
    * The integrity of the information stored in your keystore  *
    * has NOT been verified!  In order to verify its integrity, *
    * you must provide your keystore password.                  *
    *****************  WARNING WARNING WARNING  *****************
    
    Keystore type: PKCS12
    Keystore provider: SUN
    
    Your keystore contains 0 entries

Using [the "openjdk-8-jre-headless" package](https://packages.ubuntu.com/bionic/openjdk-8-jre-headless), however, will produce a valid bundle.

I added a guard to the scripts for generating the Heroku-16 and Heroku-18 stack images to guarantee that we don't introduce this regression. The failure prior to the downgrade is demonstrated by 334adbb9888e6deeff020d1af36cc7104ba6da30.