### PR TITLE
Add iproute2 package to heroku-18

### DIFF
--- a/heroku-18-build/installed-packages.txt
+++ b/heroku-18-build/installed-packages.txt
@@ -79,6 +79,7 @@ imagemagick
 imagemagick-6-common
 imagemagick-6.q16
 init-system-helpers
+iproute2
 iputils-tracepath
 krb5-multidev
 language-pack-en
@@ -295,6 +296,7 @@ libmcrypt4
 libmemcached-dev
 libmemcached11
 libmemcachedutil2
+libmnl0
 libmount1
 libmpc3
 libmpdec2

--- a/heroku-18/bin/heroku-18.sh
+++ b/heroku-18/bin/heroku-18.sh
@@ -103,6 +103,7 @@ apt-get install -y --no-install-recommends \
     git \
     gsfonts \
     imagemagick \
+    iproute2 \
     iputils-tracepath \
     language-pack-en \
     less \

--- a/heroku-18/installed-packages.txt
+++ b/heroku-18/installed-packages.txt
@@ -52,6 +52,7 @@ imagemagick
 imagemagick-6-common
 imagemagick-6.q16
 init-system-helpers
+iproute2
 iputils-tracepath
 language-pack-en
 language-pack-en-base
@@ -85,6 +86,7 @@ libdbus-1-3
 libdebconfclient0
 libdns1100
 libedit2
+libelf1
 liberror-perl
 libev4
 libevent-2.1-6
@@ -155,6 +157,7 @@ libmagickcore-6.q16-3
 libmagickwand-6.q16-3
 libmcrypt4
 libmemcached11
+libmnl0
 libmount1
 libmpdec2
 libmysqlclient20


### PR DESCRIPTION
This will add the `ip` command, which is already present on cedar-14 and heroku-16. It is required for [heroku-exec](https://devcenter.heroku.com/articles/exec).