### PR TITLE
Install libseccomp-dev package

### DIFF
--- a/heroku-16-build/bin/heroku-16-build.sh
+++ b/heroku-16-build/bin/heroku-16-build.sh
@@ -53,6 +53,7 @@ apt-get install -y --force-yes \
     librabbitmq-dev \
     libreadline-dev \
     librtmp-dev \
+    libseccomp-dev \
     libselinux1-dev \
     libsemanage1-dev \
     libsodium-dev \

--- a/heroku-16-build/installed-packages.txt
+++ b/heroku-16-build/installed-packages.txt
@@ -376,6 +376,7 @@ libsasl2-2
 libsasl2-dev
 libsasl2-modules
 libsasl2-modules-db
+libseccomp-dev
 libseccomp2
 libselinux1
 libselinux1-dev

--- a/heroku-16/bin/heroku-16.sh
+++ b/heroku-16/bin/heroku-16.sh
@@ -111,6 +111,7 @@ apt-get install -y --force-yes \
     libmemcached11 \
     libmysqlclient20 \
     librabbitmq4 \
+    libseccomp2 \
     libsodium18 \
     libuv1 \
     libxslt1.1 \

--- a/heroku-16/bin/heroku-16.sh
+++ b/heroku-16/bin/heroku-16.sh
@@ -84,8 +84,8 @@ PGDG_ACCC4CF8
 apt-get update
 apt-get upgrade -y --force-yes
 apt-get install -y --force-yes \
-    apt-utils \
     apt-transport-https \
+    apt-utils \
     bind9-host \
     bzip2 \
     coreutils \
@@ -110,8 +110,8 @@ apt-get install -y --force-yes \
     libmcrypt4 \
     libmemcached11 \
     libmysqlclient20 \
-    libsodium18 \
     librabbitmq4 \
+    libsodium18 \
     libuv1 \
     libxslt1.1 \
     locales \

--- a/heroku-18-build/bin/heroku-18-build.sh
+++ b/heroku-18-build/bin/heroku-18-build.sh
@@ -54,6 +54,7 @@ apt-get install -y --force-yes --no-install-recommends \
     librabbitmq-dev \
     libreadline-dev \
     librtmp-dev \
+    libseccomp-dev \
     libselinux1-dev \
     libsemanage1-dev \
     libsodium-dev \

--- a/heroku-18-build/installed-packages.txt
+++ b/heroku-18-build/installed-packages.txt
@@ -368,6 +368,7 @@ libruby2.5
 libsasl2-2
 libsasl2-dev
 libsasl2-modules-db
+libseccomp-dev
 libseccomp2
 libselinux1
 libselinux1-dev

--- a/heroku-18/bin/heroku-18.sh
+++ b/heroku-18/bin/heroku-18.sh
@@ -123,6 +123,7 @@ apt-get install -y --no-install-recommends \
     libmemcached11 \
     libmysqlclient20 \
     librabbitmq4 \
+    libseccomp2 \
     libsodium23 \
     libuv1 \
     libxslt1.1 \

--- a/heroku-18/bin/heroku-18.sh
+++ b/heroku-18/bin/heroku-18.sh
@@ -89,8 +89,8 @@ PGDG_ACCC4CF8
 apt-get update
 apt-get upgrade -y
 apt-get install -y --no-install-recommends \
-    apt-utils \
     apt-transport-https \
+    apt-utils \
     bind9-host \
     bzip2 \
     coreutils \
@@ -122,18 +122,18 @@ apt-get install -y --no-install-recommends \
     libmcrypt4 \
     libmemcached11 \
     libmysqlclient20 \
-    libsodium23 \
     librabbitmq4 \
+    libsodium23 \
     libuv1 \
     libxslt1.1 \
-    lsb-release \
     locales \
+    lsb-release \
     make \
     netcat-openbsd \
     openssh-client \
     openssh-server \
-    postgresql-client-10 \
     patch \
+    postgresql-client-10 \
     python \
     rename \
     rsync \


### PR DESCRIPTION
This guarantees the availability of libseccomp2 at runtime and libseccomp-dev for builds.