### PR TITLE
Add libsasl2-modules to heroku-18

### DIFF
--- a/heroku-18-build/installed-packages.txt
+++ b/heroku-18-build/installed-packages.txt
@@ -367,6 +367,7 @@ librtmp1
 libruby2.5
 libsasl2-2
 libsasl2-dev
+libsasl2-modules
 libsasl2-modules-db
 libseccomp2
 libselinux1

--- a/heroku-18/bin/heroku-18.sh
+++ b/heroku-18/bin/heroku-18.sh
@@ -122,6 +122,7 @@ apt-get install -y --no-install-recommends \
     libmcrypt4 \
     libmemcached11 \
     libmysqlclient20 \
+    libsasl2-modules \
     libsodium23 \
     librabbitmq4 \
     libuv1 \

--- a/heroku-18/installed-packages.txt
+++ b/heroku-18/installed-packages.txt
@@ -191,6 +191,7 @@ libroken18-heimdal
 librtmp1
 libruby2.5
 libsasl2-2
+libsasl2-modules
 libsasl2-modules-db
 libseccomp2
 libselinux1


### PR DESCRIPTION
present in cedar-14 and heroku-16

without this package, standard SASL authentication mechanisms cannot be used:

- anonymous
- crammd5
- digestmd5
- login
- ntlm
- plain