### PR TITLE
Use a single equal sign

### DIFF
--- a/bin/publish.sh
+++ b/bin/publish.sh
@@ -8,7 +8,7 @@ docker login -u $DOCKER_HUB_USERNAME -p $DOCKER_HUB_PASSWORD
 
 docker push $IMAGE_TAG
 
-if [ "$STACK" == "cedar-14" ]; then
+if [ "$STACK" = "cedar-14" ]; then
   docker tag $IMAGE_TAG herokutest/cedar:latest
   docker push herokutest/cedar:latest
 fi


### PR DESCRIPTION
To avoid the following error:

> +[ heroku-18 == cedar-14 ]
> bin/publish.sh: 11: [: heroku-18: unexpected operator