### PR TITLE
Use Ubuntu bionic packages for Heroku 18 provided by postgres

### DIFF
--- a/heroku-18/bin/heroku-18.sh
+++ b/heroku-18/bin/heroku-18.sh
@@ -14,7 +14,7 @@ apt-get update
 apt-get install -y --no-install-recommends gnupg
 
 cat >>/etc/apt/sources.list <<EOF
-deb http://apt.postgresql.org/pub/repos/apt/ xenial-pgdg main
+deb http://apt.postgresql.org/pub/repos/apt/ bionic-pgdg main
 EOF
 
 apt-key add - <<'PGDG_ACCC4CF8'


### PR DESCRIPTION
to avoid confusion in the future, there is no reason behind it other than that the bionic endpoint didn't exist when we started creating Heroku 18 images