### PR TITLE
Add libzip

### DIFF
--- a/heroku-16-build/bin/heroku-16-build.sh
+++ b/heroku-16-build/bin/heroku-16-build.sh
@@ -65,6 +65,7 @@ apt-get install -y --force-yes \
     libxml2-dev \
     libxslt-dev \
     libyaml-dev \
+    libzip-dev \
     postgresql-server-dev-10 \
     python-dev \
     ruby-dev \

--- a/heroku-16-build/installed-packages.txt
+++ b/heroku-16-build/installed-packages.txt
@@ -467,6 +467,8 @@ libxt6
 libxtables11
 libyaml-0-2
 libyaml-dev
+libzip-dev
+libzip4
 linux-libc-dev
 locales
 login

--- a/heroku-16/bin/heroku-16.sh
+++ b/heroku-16/bin/heroku-16.sh
@@ -115,6 +115,7 @@ apt-get install -y --force-yes \
     libsodium18 \
     libuv1 \
     libxslt1.1 \
+    libzip4 \
     locales \
     make \
     netcat-openbsd \

--- a/heroku-16/installed-packages.txt
+++ b/heroku-16/installed-packages.txt
@@ -256,6 +256,7 @@ libxrender1
 libxslt1.1
 libxtables11
 libyaml-0-2
+libzip4
 locales
 login
 lsb-base

--- a/heroku-18-build/bin/heroku-18-build.sh
+++ b/heroku-18-build/bin/heroku-18-build.sh
@@ -68,6 +68,7 @@ apt-get install -y --force-yes --no-install-recommends \
     libxml2-dev \
     libxslt-dev \
     libyaml-dev \
+    libzip-dev \
     postgresql-server-dev-10 \
     python-dev \
     ruby-dev \

--- a/heroku-18-build/installed-packages.txt
+++ b/heroku-18-build/installed-packages.txt
@@ -450,6 +450,8 @@ libxt-dev
 libxt6
 libyaml-0-2
 libyaml-dev
+libzip-dev
+libzip4
 libzstd1
 linux-libc-dev
 locales

--- a/heroku-18/bin/heroku-18.sh
+++ b/heroku-18/bin/heroku-18.sh
@@ -129,6 +129,7 @@ apt-get install -y --no-install-recommends \
     libsodium23 \
     libuv1 \
     libxslt1.1 \
+    libzip4 \
     locales \
     lsb-release \
     make \

--- a/heroku-18/installed-packages.txt
+++ b/heroku-18/installed-packages.txt
@@ -227,6 +227,7 @@ libxml2
 libxpm4
 libxslt1.1
 libyaml-0-2
+libzip4
 libzstd1
 locales
 login


### PR DESCRIPTION
PHP 7.3, due this winter, will no longer bundle libzip for some core functionality.

The PR doesn't add it for cedar-14, as that's about to be EOL, and the version included there is very old and not suitable.

Sizes:

| package | stack | size |
|---|---|---|
| `libzip4` | xenial | 95.0 kB |
| `libzip4` | bionic | 100.0 kB |
| `libzip-dev` | xenial | 419.0 kB |
| `libzip-dev` | bionic | 429.0 kB |
