### PR TITLE
Add libxcb.

### DIFF
--- a/heroku-18/bin/heroku-18.sh
+++ b/heroku-18/bin/heroku-18.sh
@@ -128,6 +128,7 @@ apt-get install -y --no-install-recommends \
     libseccomp2 \
     libsodium23 \
     libuv1 \
+    libxcb-shm0 \
     libxslt1.1 \
     locales \
     lsb-release \

--- a/heroku-18/installed-packages.txt
+++ b/heroku-18/installed-packages.txt
@@ -220,6 +220,7 @@ libwrap0
 libx11-6
 libx11-data
 libxau6
+libxcb-shm0
 libxcb1
 libxdmcp6
 libxext6


### PR DESCRIPTION
This library is used inside of ImageMagick (included in the stack image), and its development headers are already included in the development image. Its omission in the stack is probably an error, and lead to tickets such as https://support.heroku.com/tickets/625888.

There are probably other packages we're missing. I have no idea how to exhaustively list which libs ImageMagick might try to load.