### PR TITLE
New images from travis

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -8,9 +8,9 @@ branches:
   - master
 env:
   matrix:
-  - STACK=cedar-14 IMAGE_TAG=herokutest/cedar:14
-  - STACK=heroku-16 IMAGE_TAG=herokutest/heroku:16
-  - STACK=heroku-18 IMAGE_TAG=herokutest/heroku:18
+  - STACK=cedar-14 IMAGE_TAG=heroku/cedar:14
+  - STACK=heroku-16 IMAGE_TAG=heroku/heroku:16
+  - STACK=heroku-18 IMAGE_TAG=heroku/heroku:18
   global:
   - secure: qsOv8gjVqCeV7kqx8FntMKD51EZCO2j7oTY8fWwqgndRCT5kHtcJA0vGMW0rjGDlDMuEB5wyUc2RT9ZWMslyKWxgS4Su5zSdAlE8D6TXXpHDU1ZPmOA+cnNm4TIMIrcUlGeCWcK4NNe8Vg7VvrTstooLB/ZjgaCKylkxs7zWq2g= # DOCKER_HUB_USERNAME
   - secure: Dlf4eHJVTQ1bCZuLaaNoKjUmS8SL7Jn2BZCdP7UHZhte+RKchCjajhoObT/fAZ3c5EFfV2pd8NKkWPW0REwN/lodgRPeslYiyNaiIRCVoKRGASxHXHO17wwkMNor2Bi7u6InL3WC1t5YbY2abVaeavtz1lAyn1XTNysc+/s1onw= # DOCKER_HUB_PASSWORD

--- a/BUILD.md
+++ b/BUILD.md
@@ -1,12 +1,23 @@
-Building Stack Images Locally
-=============================
+# Building Stack Images Locally
 
 To build the stack images locally, run this from the repo root:
 
-    ./docker-build.sh STACK
-  
+    ./docker-build.sh STACK DOCKER_TAG
+
+For example:
+
+    ./docker-build.sh heroku-18 heroku/heroku:18
+
 The supported stacks are:
 
 * `cedar-14`
 * `heroku-16` (will also build a `heroku-16-build` image)
 * `heroku-18` (will also build a `heroku-18-build` image)
+
+
+# Releasing Stack Images
+
+When building Stack Images for release, we use the Travis build system.
+
+* Any push to master will build the images and push the `nightly` tag.
+* Any new tag will build the image and push the `latest` tag, as well as one with the name of the GIT tag.

--- a/bin/publish.sh
+++ b/bin/publish.sh
@@ -2,13 +2,15 @@
 
 set -ex
 
-./docker-build.sh $STACK $IMAGE_TAG
+tag="${IMAGE_TAG}.nightly"
+
+./docker-build.sh $STACK $TAG
 
 docker login -u $DOCKER_HUB_USERNAME -p $DOCKER_HUB_PASSWORD
 
-docker push $IMAGE_TAG
+docker push $TAG
 
 if [ "$STACK" = "cedar-14" ]; then
-  docker tag $IMAGE_TAG herokutest/cedar:latest
+  docker tag $TAG herokutest/cedar:latest
   docker push herokutest/cedar:latest
 fi

--- a/bin/publish.sh
+++ b/bin/publish.sh
@@ -2,15 +2,26 @@
 
 set -ex
 
-tag="${IMAGE_TAG}.nightly"
+nightlyTag="${IMAGE_TAG}.nightly"
 
-./docker-build.sh $STACK $TAG
+./docker-build.sh $STACK $nightlyTag
 
 docker login -u $DOCKER_HUB_USERNAME -p $DOCKER_HUB_PASSWORD
 
-docker push $TAG
+docker push $nightlyTag
 
-if [ "$STACK" = "cedar-14" ]; then
-  docker tag $TAG herokutest/cedar:latest
-  docker push herokutest/cedar:latest
+if [ -n "$TRAVIS_TAG" ]; then
+  releaseTag="${IMAGE_TAG}.${TRAVIS_TAG}"
+  latestTag="${IMAGE_TAG}"
+
+  docker tag $nightlyTag $releaseTag
+  docker tag $nightlyTag $latestTag
+
+  docker push $releaseTag
+  docker push $latestTag
+
+  if [ "$STACK" = "cedar-14" ]; then
+    docker tag $nightlyTag heroku/cedar:latest
+    docker push heroku/cedar:latest
+  fi
 fi


### PR DESCRIPTION
This finalizes #110.

* On every build on master, it will push the `.nightly` images, which are always the master branch.
* When a new GitHub release (tag) is created, it will also tag and push images to 2 locations:
    * A `.$TAG_NAME` tag, so we can retrieve previous images for rollback reasons.
    * The main image.