### PR TITLE
Deploy on all branches and tags

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -4,6 +4,7 @@ language: shell
 services:
 - docker
 branches:
+  # /!\ Every build will always trigger a deploy
   only:
   - master
   - /^v\d+(\.\d+)?(\.\d+)?(-\S*)?$/

--- a/.travis.yml
+++ b/.travis.yml
@@ -26,6 +26,3 @@ script:
 deploy:
   provider: script
   script: sh bin/publish.sh
-  on:
-    tags: true
-    branch: master


### PR DESCRIPTION
The tag/branch condition is an AND, not an OR. So this prevents us from
having nightly builds.

Deploying on everything will effectively only deploy the appropriate
tags and branches, as the deploy on happens after a build.