### PR TITLE
publish images if we run a tag

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -27,3 +27,5 @@ script:
 deploy:
   provider: script
   script: sh bin/publish.sh
+  on:
+    tags: true


### PR DESCRIPTION
right now we are only building the images on Travis and do not publish them to Docker Hub