### PR TITLE
add libmagickcore extra codecs for heroku-18

### DIFF
--- a/heroku-16/bin/heroku-16.sh
+++ b/heroku-16/bin/heroku-16.sh
@@ -108,6 +108,7 @@ apt-get install -y --force-yes \
     libgd3 \
     libgnutls-openssl27 \
     libgnutlsxx28 \
+    libmagickcore-6.q16-2-extra \
     libmcrypt4 \
     libmemcached11 \
     libmysqlclient20 \

--- a/heroku-18/bin/heroku-18.sh
+++ b/heroku-18/bin/heroku-18.sh
@@ -129,6 +129,7 @@ apt-get install -y --no-install-recommends \
     libgraphite2-3 \
     libgs9 \
     libharfbuzz0b \
+    libmagickcore-6.q16-3-extra \
     libmcrypt4 \
     libmemcached11 \
     libmysqlclient20 \

--- a/heroku-18/installed-packages.txt
+++ b/heroku-18/installed-packages.txt
@@ -102,6 +102,8 @@ libdatrie1
 libdb5.3
 libdbus-1-3
 libdebconfclient0
+libdjvulibre-text
+libdjvulibre21
 libdns1100
 libedit2
 libelf1
@@ -151,6 +153,7 @@ libicu60
 libidn11
 libidn2-0
 libijs-0.35
+libilmbase12
 libirs160
 libisc169
 libisccc160
@@ -180,6 +183,7 @@ liblzma5
 libmagic-mgc
 libmagic1
 libmagickcore-6.q16-3
+libmagickcore-6.q16-3-extra
 libmagickwand-6.q16-3
 libmcrypt4
 libmemcached11
@@ -195,6 +199,7 @@ libncursesw5
 libnettle6
 libnghttp2-14
 libnpth0
+libopenexr22
 libp11-kit0
 libpam-modules
 libpam-modules-bin
@@ -255,6 +260,7 @@ libuuid1
 libuv1
 libwebp6
 libwind0-heimdal
+libwmf0.2-7
 libwrap0
 libx11-6
 libx11-data


### PR DESCRIPTION
this package is required for e.g. SVG manipulation

heroku-16 has it, but not through an explicit dependency, so we're adding that as well