### PR TITLE
Ensure we are still uploading SHA for backwards compatibility reasons

### DIFF
--- a/tools/bin/upload-image
+++ b/tools/bin/upload-image
@@ -47,3 +47,12 @@ curl \
     --header "Content-Type: application/octet-stream" \
     --upload-file "$IMG_GZ" \
     "$PUT_URL"
+
+display Uploading SHA to S3
+SHA_PUT_URL=$(jq -r .sha_put_url "$IMG_MANIFEST")
+curl \
+    --silent --show-error \
+    --user-agent 'Stack Image Tools' \
+    --header "Content-Type: application/octet-stream" \
+    --upload-file "$IMG_SHA256" \
+    "$SHA_PUT_URL"


### PR DESCRIPTION
We need to upload the SHA in order for compatibility with other processes. 