### PR TITLE
Update postgres packages to version 11

### DIFF
--- a/cedar-14/bin/cedar-14.sh
+++ b/cedar-14/bin/cedar-14.sh
@@ -131,8 +131,8 @@ apt-get install -y --force-yes \
     openjdk-7-jre-headless \
     openssh-client \
     openssh-server \
-    postgresql-client-10 \
-    postgresql-server-dev-10 \
+    postgresql-client-11 \
+    postgresql-server-dev-11 \
     psmisc \
     python \
     python-dev \

--- a/cedar-14/installed-packages.txt
+++ b/cedar-14/installed-packages.txt
@@ -864,10 +864,10 @@ plymouth
 policykit-1
 policykit-1-gnome
 poppler-data
-postgresql-client-10
+postgresql-client-11
 postgresql-client-common
 postgresql-common
-postgresql-server-dev-10
+postgresql-server-dev-11
 procps
 psmisc
 python

--- a/heroku-16-build/bin/heroku-16-build.sh
+++ b/heroku-16-build/bin/heroku-16-build.sh
@@ -66,7 +66,7 @@ apt-get install -y --force-yes \
     libxslt-dev \
     libyaml-dev \
     libzip-dev \
-    postgresql-server-dev-10 \
+    postgresql-server-dev-11 \
     python-dev \
     ruby-dev \
     zlib1g-dev \

--- a/heroku-16-build/installed-packages.txt
+++ b/heroku-16-build/installed-packages.txt
@@ -10,6 +10,7 @@ base-files
 base-passwd
 bash
 bind9-host
+binfmt-support
 binutils
 bison
 bsdutils
@@ -18,6 +19,7 @@ bzip2
 bzip2-doc
 ca-certificates
 ca-certificates-java
+clang-6.0
 comerr-dev
 coreutils
 cpp
@@ -87,6 +89,8 @@ krb5-multidev
 language-pack-en
 language-pack-en-base
 less
+lib32gcc1
+lib32stdc++6
 libacl1
 libacl1-dev
 libalgorithm-diff-perl
@@ -124,6 +128,7 @@ libc-bin
 libc-dev-bin
 libc6
 libc6-dev
+libc6-i386
 libcairo-gobject2
 libcairo-script-interpreter2
 libcairo2
@@ -136,6 +141,8 @@ libcc1-0
 libcdt5
 libcgraph6
 libcilkrts5
+libclang-common-6.0-dev
+libclang1-6.0
 libcomerr2
 libcroco3
 libcryptsetup4
@@ -261,6 +268,7 @@ libjpeg-turbo8-dev
 libjpeg8
 libjpeg8-dev
 libjs-jquery
+libjsoncpp1
 libk5crypto3
 libkadm5clnt-mit9
 libkadm5srv-mit9
@@ -277,6 +285,7 @@ liblcms2-2
 liblcms2-dev
 libldap-2.4-2
 libldap2-dev
+libllvm6.0
 liblqr-1-0
 liblqr-1-0-dev
 liblsan0
@@ -319,6 +328,10 @@ libncursesw5-dev
 libnetpbm10
 libnetpbm10-dev
 libnettle6
+libobjc-5-dev
+libobjc4
+libomp-dev
+libomp5
 libopenexr-dev
 libopenexr22
 libp11-kit-dev
@@ -340,6 +353,7 @@ libpcre3-dev
 libpcre32-3
 libpcrecpp0v5
 libperl5.22
+libpipeline1
 libpixman-1-0
 libpixman-1-dev
 libpng12-0
@@ -470,6 +484,9 @@ libyaml-dev
 libzip-dev
 libzip4
 linux-libc-dev
+llvm-6.0
+llvm-6.0-dev
+llvm-6.0-runtime
 locales
 login
 logrotate
@@ -505,10 +522,10 @@ perl-modules-5.22
 pgdg-keyring
 pkg-config
 poppler-data
-postgresql-client-10
+postgresql-client-11
 postgresql-client-common
 postgresql-common
-postgresql-server-dev-10
+postgresql-server-dev-11
 procps
 python
 python-dev

--- a/heroku-16/bin/heroku-16.sh
+++ b/heroku-16/bin/heroku-16.sh
@@ -123,7 +123,7 @@ apt-get install -y --force-yes \
     netcat-openbsd \
     openssh-client \
     openssh-server \
-    postgresql-client-10 \
+    postgresql-client-11 \
     python \
     ruby \
     socat \

--- a/heroku-16/installed-packages.txt
+++ b/heroku-16/installed-packages.txt
@@ -310,7 +310,7 @@ perl-base
 perl-modules-5.22
 pgdg-keyring
 poppler-data
-postgresql-client-10
+postgresql-client-11
 postgresql-client-common
 procps
 python

--- a/heroku-18-build/bin/heroku-18-build.sh
+++ b/heroku-18-build/bin/heroku-18-build.sh
@@ -69,7 +69,7 @@ apt-get install -y --force-yes --no-install-recommends \
     libxslt-dev \
     libyaml-dev \
     libzip-dev \
-    postgresql-server-dev-10 \
+    postgresql-server-dev-11 \
     python-dev \
     ruby-dev \
     zlib1g-dev \

--- a/heroku-18-build/installed-packages.txt
+++ b/heroku-18-build/installed-packages.txt
@@ -10,6 +10,7 @@ base-files
 base-passwd
 bash
 bind9-host
+binfmt-support
 binutils
 binutils-common
 binutils-x86-64-linux-gnu
@@ -19,6 +20,7 @@ build-essential
 bzip2
 ca-certificates
 ca-certificates-java
+clang-6.0
 comerr-dev
 coreutils
 cpp
@@ -85,6 +87,8 @@ krb5-multidev
 language-pack-en
 language-pack-en-base
 less
+lib32gcc1
+lib32stdc++6
 libacl1
 libacl1-dev
 libapt-inst2.0
@@ -116,6 +120,7 @@ libc-bin
 libc-dev-bin
 libc6
 libc6-dev
+libc6-i386
 libcairo-gobject2
 libcairo-script-interpreter2
 libcairo2
@@ -126,6 +131,8 @@ libcap-ng0
 libcap2
 libcc1-0
 libcilkrts5
+libclang-common-6.0-dev
+libclang1-6.0
 libcom-err2
 libcroco3
 libcups2
@@ -170,6 +177,7 @@ libfontconfig1
 libfontconfig1-dev
 libfreetype6
 libfreetype6-dev
+libgc1c2
 libgcc-7-dev
 libgcc1
 libgcrypt20
@@ -252,6 +260,7 @@ libjpeg-turbo8-dev
 libjpeg8
 libjpeg8-dev
 libjson-c3
+libjsoncpp1
 libk5crypto3
 libkadm5clnt-mit11
 libkadm5srv-mit11
@@ -270,6 +279,7 @@ liblcms2-dev
 libldap-2.4-2
 libldap-common
 libldap2-dev
+libllvm6.0
 liblqr-1-0
 liblqr-1-0-dev
 liblsan0
@@ -315,6 +325,8 @@ libnetpbm10-dev
 libnettle6
 libnghttp2-14
 libnpth0
+libobjc-7-dev
+libobjc4
 libopenexr-dev
 libopenexr22
 libp11-kit-dev
@@ -335,6 +347,7 @@ libpcre3-dev
 libpcre32-3
 libpcrecpp0v5
 libperl5.26
+libpipeline1
 libpixman-1-0
 libpixman-1-dev
 libpng-dev
@@ -454,6 +467,9 @@ libzip-dev
 libzip4
 libzstd1
 linux-libc-dev
+llvm-6.0
+llvm-6.0-dev
+llvm-6.0-runtime
 locales
 login
 lsb-base
@@ -484,10 +500,10 @@ pgdg-keyring
 pinentry-curses
 pkg-config
 poppler-data
-postgresql-client-10
+postgresql-client-11
 postgresql-client-common
 postgresql-common
-postgresql-server-dev-10
+postgresql-server-dev-11
 procps
 python
 python-dev

--- a/heroku-18/bin/heroku-18.sh
+++ b/heroku-18/bin/heroku-18.sh
@@ -158,7 +158,7 @@ apt-get install -y --no-install-recommends \
     openssh-client \
     openssh-server \
     patch \
-    postgresql-client-10 \
+    postgresql-client-11 \
     python \
     rename \
     rsync \

--- a/heroku-18/installed-packages.txt
+++ b/heroku-18/installed-packages.txt
@@ -304,7 +304,7 @@ perl-modules-5.26
 pgdg-keyring
 pinentry-curses
 poppler-data
-postgresql-client-10
+postgresql-client-11
 postgresql-client-common
 procps
 python


### PR DESCRIPTION
Update client libraries to use version 11 of postgresql packages.

[Failing build](https://travis-ci.org/heroku/stack-images/builds/503646642) because of the dockerhub issues going on right now. The build itself is passing, just the final image push is failing.