### PR TITLE
Explicitly install lsb-release on Heroku-16

### DIFF
--- a/heroku-16/bin/heroku-16.sh
+++ b/heroku-16/bin/heroku-16.sh
@@ -130,6 +130,7 @@ apt-get install -y --force-yes \
     libxslt1.1 \
     libzip4 \
     locales \
+    lsb-release \
     make \
     netcat-openbsd \
     openssh-client \


### PR DESCRIPTION
Previously the package was pulled in implicitly, due to being in the `Recommends` dependency list of `postgresql-client-common`. However the latest update of `postgresql-client-common` no longer includes it in its `Recommends`, so we now have to install `lsb-release` explicitly on Heroku-16.

The other stacks were not affected, since:
* Heroku-18 already installs `lsb-release` explicitly, since the use of `--no-install-recommends` there forces us to be more intentional about our dependencies (part of the reason for us switching to using it that flag)
* The Trusty version of `postgresql-client-common` is not receiving updates (since Ubuntu 14.04 is EOL) so Cedar-14's package is unchanged

Fixes #144 / [W-6624950](https://gus.my.salesforce.com/a07B0000007VoFJIA0).