### PR TITLE
Add libc-client2007e to the stack image

### DIFF
--- a/cedar-14/bin/cedar-14.sh
+++ b/cedar-14/bin/cedar-14.sh
@@ -191,6 +191,7 @@ apt-get install -y --force-yes \
     iputils-tracepath \
     language-pack-en \
     libbz2-dev \
+    libc-client2007e \
     libcurl4-openssl-dev \
     libev-dev \
     libevent-dev \

--- a/cedar-14/installed-packages.txt
+++ b/cedar-14/installed-packages.txt
@@ -445,6 +445,7 @@ libbsd0
 libbz2-1.0
 libbz2-dev
 libc-bin
+libc-client2007e
 libc-dev-bin
 libc6
 libc6-dev
@@ -834,6 +835,7 @@ manpages
 manpages-dev
 mawk
 mime-support
+mlock
 module-init-tools
 mount
 mountall

--- a/heroku-16-build/bin/heroku-16-build.sh
+++ b/heroku-16-build/bin/heroku-16-build.sh
@@ -19,6 +19,7 @@ apt-get install -y --force-yes \
     libaudit-dev \
     libbsd-dev \
     libbz2-dev \
+    libc-client2007e-dev \
     libcairo2-dev \
     libcap-dev \
     libcurl4-openssl-dev \

--- a/heroku-16-build/installed-packages.txt
+++ b/heroku-16-build/installed-packages.txt
@@ -130,6 +130,8 @@ libbsd0
 libbz2-1.0
 libbz2-dev
 libc-bin
+libc-client2007e
+libc-client2007e-dev
 libc-dev-bin
 libc6
 libc6-dev
@@ -511,6 +513,7 @@ mawk
 mercurial
 mercurial-common
 mime-support
+mlock
 mount
 mtools
 multiarch-support

--- a/heroku-16/bin/heroku-16.sh
+++ b/heroku-16/bin/heroku-16.sh
@@ -108,6 +108,7 @@ apt-get install -y --force-yes \
     imagemagick \
     iputils-tracepath \
     language-pack-en \
+    libc-client2007e \
     libcurl3 \
     libev4 \
     libevent-2.0-5 \

--- a/heroku-16/installed-packages.txt
+++ b/heroku-16/installed-packages.txt
@@ -85,6 +85,7 @@ libblkid1
 libbsd0
 libbz2-1.0
 libc-bin
+libc-client2007e
 libc-dev-bin
 libc6
 libc6-dev
@@ -289,6 +290,7 @@ manpages
 manpages-dev
 mawk
 mime-support
+mlock
 mount
 mtools
 multiarch-support

--- a/heroku-18-build/bin/heroku-18-build.sh
+++ b/heroku-18-build/bin/heroku-18-build.sh
@@ -20,6 +20,7 @@ apt-get install -y --force-yes --no-install-recommends \
     libaudit-dev \
     libbsd-dev \
     libbz2-dev \
+    libc-client2007e-dev \
     libcairo2-dev \
     libcap-dev \
     libcurl4-openssl-dev \

--- a/heroku-18-build/installed-packages.txt
+++ b/heroku-18-build/installed-packages.txt
@@ -118,6 +118,8 @@ libbsd0
 libbz2-1.0
 libbz2-dev
 libc-bin
+libc-client2007e
+libc-client2007e-dev
 libc-dev-bin
 libc6
 libc6-dev
@@ -481,6 +483,7 @@ mawk
 mercurial
 mercurial-common
 mime-support
+mlock
 mount
 mtools
 multiarch-support

--- a/heroku-18/bin/heroku-18.sh
+++ b/heroku-18/bin/heroku-18.sh
@@ -121,6 +121,7 @@ apt-get install -y --no-install-recommends \
     language-pack-en \
     less \
     libargon2-0 \
+    libc-client2007e \
     libcairo2 \
     libcroco3 \
     libcurl4 \

--- a/heroku-18/installed-packages.txt
+++ b/heroku-18/installed-packages.txt
@@ -86,6 +86,7 @@ libblkid1
 libbsd0
 libbz2-1.0
 libc-bin
+libc-client2007e
 libc6
 libcairo2
 libcap-ng0
@@ -284,6 +285,7 @@ lsb-release
 make
 mawk
 mime-support
+mlock
 mount
 mtools
 multiarch-support


### PR DESCRIPTION
for all stacks

this prevents us from having to maintain a custom patched version inside buildpacks (see https://bugs.launchpad.net/ubuntu/+source/uw-imap/+bug/1834340)