### PR TITLE
Temporarily pin libpq5 and libpq-dev to v11

### DIFF
--- a/heroku-16/bin/heroku-16.sh
+++ b/heroku-16/bin/heroku-16.sh
@@ -9,7 +9,17 @@ deb http://archive.ubuntu.com/ubuntu/ xenial main universe
 deb http://archive.ubuntu.com/ubuntu/ xenial-security main universe
 deb http://archive.ubuntu.com/ubuntu/ xenial-updates main universe
 
-deb http://apt.postgresql.org/pub/repos/apt/ xenial-pgdg main
+# Use the PG11 version of libpq to work around:
+# https://github.com/heroku/stack-images/issues/147
+# We have to specify both 'main' and '11' since the latter only contains a subset of the packages.
+deb http://apt.postgresql.org/pub/repos/apt/ xenial-pgdg main 11
+EOF
+
+# Give priority to the PG11 version of libpq, rather than main's PG12.
+cat >/etc/apt/preferences.d/pgdg.pref <<EOF
+Package: *
+Pin: release o=apt.postgresql.org,c=11
+Pin-Priority: 600
 EOF
 
 apt-key add - <<'PGDG_ACCC4CF8'

--- a/heroku-18/bin/heroku-18.sh
+++ b/heroku-18/bin/heroku-18.sh
@@ -13,8 +13,18 @@ EOF
 apt-get update
 apt-get install -y --no-install-recommends gnupg
 
+# Use the PG11 version of libpq to work around:
+# https://github.com/heroku/stack-images/issues/147
+# We have to specify both 'main' and '11' since the latter only contains a subset of the packages.
 cat >>/etc/apt/sources.list <<EOF
-deb http://apt.postgresql.org/pub/repos/apt/ bionic-pgdg main
+deb http://apt.postgresql.org/pub/repos/apt/ bionic-pgdg main 11
+EOF
+
+# Give priority to the PG11 version of libpq, rather than main's PG12.
+cat >/etc/apt/preferences.d/pgdg.pref <<EOF
+Package: *
+Pin: release o=apt.postgresql.org,c=11
+Pin-Priority: 600
 EOF
 
 apt-key add - <<'PGDG_ACCC4CF8'


### PR DESCRIPTION
Since libpq 12 includes a breaking change (more strict validation of connection parameters) which causes connection errors at runtime for customers with invalid database configuration settings.

This unblocks new stack image releases until an assessment of the number of customers affected/outreach can be performed.

The version is being pinned using the approach here:
https://wiki.postgresql.org/wiki/Apt/FAQ#I_want_libpq5_for_version_X.2C_but_there_is_only_version_Y_in_the_repository

Cedar-14's build script did not need to be updated, since PostgreSQL 12 is not available in the `trusty-pgdg` archive (due to Ubuntu 14.04 EOL).

Refs #147 / [W-6780695](https://gus.lightning.force.com/lightning/r/ADM_Work__c/a07B0000007azZLIAY/view).