### PR TITLE
Add cmake package to heroku-16/18 build images

### DIFF
--- a/heroku-16-build/bin/heroku-16-build.sh
+++ b/heroku-16-build/bin/heroku-16-build.sh
@@ -10,6 +10,7 @@ apt-get install -y --force-yes \
     bison \
     build-essential \
     bzr \
+    cmake \
     gettext \
     git \
     libacl1-dev \

--- a/heroku-16-build/installed-packages.txt
+++ b/heroku-16-build/installed-packages.txt
@@ -21,6 +21,8 @@ bzr
 ca-certificates
 ca-certificates-java
 clang-6.0
+cmake
+cmake-data
 comerr-dev
 coreutils
 cpp
@@ -105,6 +107,7 @@ libapparmor1
 libapt-inst2.0
 libapt-pkg-dev
 libapt-pkg5.0
+libarchive13
 libasan2
 libasn1-8-heimdal
 libasprintf-dev

--- a/heroku-18-build/bin/heroku-18-build.sh
+++ b/heroku-18-build/bin/heroku-18-build.sh
@@ -11,6 +11,7 @@ apt-get install -y --force-yes --no-install-recommends \
     bison \
     build-essential \
     bzr \
+    cmake \
     gettext \
     git \
     libacl1-dev \

--- a/heroku-18-build/installed-packages.txt
+++ b/heroku-18-build/installed-packages.txt
@@ -22,6 +22,8 @@ bzr
 ca-certificates
 ca-certificates-java
 clang-6.0
+cmake
+cmake-data
 comerr-dev
 coreutils
 cpp
@@ -95,6 +97,7 @@ libacl1-dev
 libapt-inst2.0
 libapt-pkg-dev
 libapt-pkg5.0
+libarchive13
 libargon2-0
 libargon2-0-dev
 libasan4
@@ -376,6 +379,7 @@ librabbitmq-dev
 librabbitmq4
 libreadline-dev
 libreadline7
+librhash0
 libroken18-heimdal
 librsvg2-2
 librsvg2-common


### PR DESCRIPTION
I'd like to use the [pronto gem](https://github.com/prontolabs/pronto) on one of our internal apps that makes use of the Heroku-16-build image in its testing environment. The pronto gem builds with native bindings including [`libgit2/rugged`](https://github.com/libgit2/rugged) which has a `cmake` dependency. See:
```
# ...
# library versions scrubbed in this example with XXX
       Gem::Ext::BuildError: ERROR: Failed to build gem native extension.

       current directory:
       /app/vendor/bundle/ruby/X.X.X/gems/rugged-X.X.X/ext/rugged
       /app/vendor/ruby-X.X.X/bin/ruby -r ./siteconfXXXvwnd.rb extconf.rb
       checking for gmake... no
       checking for make... yes
       checking for cmake... no
       ERROR: CMake is required to build Rugged.
       *** extconf.rb failed ***
       Could not create Makefile due to some reason, probably lack of necessary
       libraries and/or headers.  Check the mkmf.log file for more details.  You may
       need configuration options.
# ...
```