### PR TITLE
Update postgresql-client, postgresql-server-dev and libpq to PG12

### DIFF
--- a/heroku-16-build/bin/heroku-16-build.sh
+++ b/heroku-16-build/bin/heroku-16-build.sh
@@ -71,7 +71,7 @@ apt-get install -y --force-yes \
     libyaml-dev \
     libzip-dev \
     mercurial \
-    postgresql-server-dev-11 \
+    postgresql-server-dev-12 \
     python-dev \
     ruby-dev \
     zlib1g-dev \

--- a/heroku-16-build/installed-packages.txt
+++ b/heroku-16-build/installed-packages.txt
@@ -541,10 +541,10 @@ pgdg-keyring
 pinentry-curses
 pkg-config
 poppler-data
-postgresql-client-11
+postgresql-client-12
 postgresql-client-common
 postgresql-common
-postgresql-server-dev-11
+postgresql-server-dev-12
 procps
 python
 python-bzrlib

--- a/heroku-16/bin/heroku-16.sh
+++ b/heroku-16/bin/heroku-16.sh
@@ -9,17 +9,7 @@ deb http://archive.ubuntu.com/ubuntu/ xenial main universe
 deb http://archive.ubuntu.com/ubuntu/ xenial-security main universe
 deb http://archive.ubuntu.com/ubuntu/ xenial-updates main universe
 
-# Use the PG11 version of libpq to work around:
-# https://github.com/heroku/stack-images/issues/147
-# We have to specify both 'main' and '11' since the latter only contains a subset of the packages.
-deb http://apt.postgresql.org/pub/repos/apt/ xenial-pgdg main 11
-EOF
-
-# Give priority to the PG11 version of libpq, rather than main's PG12.
-cat >/etc/apt/preferences.d/pgdg.pref <<EOF
-Package: *
-Pin: release o=apt.postgresql.org,c=11
-Pin-Priority: 600
+deb http://apt.postgresql.org/pub/repos/apt/ xenial-pgdg main
 EOF
 
 apt-key add - <<'PGDG_ACCC4CF8'
@@ -146,7 +136,7 @@ apt-get install -y --force-yes \
     netcat-openbsd \
     openssh-client \
     openssh-server \
-    postgresql-client-11 \
+    postgresql-client-12 \
     python \
     ruby \
     socat \

--- a/heroku-16/installed-packages.txt
+++ b/heroku-16/installed-packages.txt
@@ -312,7 +312,7 @@ perl-base
 perl-modules-5.22
 pgdg-keyring
 poppler-data
-postgresql-client-11
+postgresql-client-12
 postgresql-client-common
 procps
 python

--- a/heroku-18-build/bin/heroku-18-build.sh
+++ b/heroku-18-build/bin/heroku-18-build.sh
@@ -74,7 +74,7 @@ apt-get install -y --force-yes --no-install-recommends \
     libyaml-dev \
     libzip-dev \
     mercurial \
-    postgresql-server-dev-11 \
+    postgresql-server-dev-12 \
     python-dev \
     ruby-dev \
     zlib1g-dev \

--- a/heroku-18-build/installed-packages.txt
+++ b/heroku-18-build/installed-packages.txt
@@ -510,10 +510,10 @@ pgdg-keyring
 pinentry-curses
 pkg-config
 poppler-data
-postgresql-client-11
+postgresql-client-12
 postgresql-client-common
 postgresql-common
-postgresql-server-dev-11
+postgresql-server-dev-12
 procps
 python
 python-bzrlib

--- a/heroku-18/bin/heroku-18.sh
+++ b/heroku-18/bin/heroku-18.sh
@@ -13,18 +13,8 @@ EOF
 apt-get update
 apt-get install -y --no-install-recommends gnupg
 
-# Use the PG11 version of libpq to work around:
-# https://github.com/heroku/stack-images/issues/147
-# We have to specify both 'main' and '11' since the latter only contains a subset of the packages.
 cat >>/etc/apt/sources.list <<EOF
-deb http://apt.postgresql.org/pub/repos/apt/ bionic-pgdg main 11
-EOF
-
-# Give priority to the PG11 version of libpq, rather than main's PG12.
-cat >/etc/apt/preferences.d/pgdg.pref <<EOF
-Package: *
-Pin: release o=apt.postgresql.org,c=11
-Pin-Priority: 600
+deb http://apt.postgresql.org/pub/repos/apt/ bionic-pgdg main
 EOF
 
 apt-key add - <<'PGDG_ACCC4CF8'
@@ -180,7 +170,7 @@ apt-get install -y --no-install-recommends \
     openssh-client \
     openssh-server \
     patch \
-    postgresql-client-11 \
+    postgresql-client-12 \
     python \
     rename \
     rsync \

--- a/heroku-18/installed-packages.txt
+++ b/heroku-18/installed-packages.txt
@@ -306,7 +306,7 @@ perl-modules-5.26
 pgdg-keyring
 pinentry-curses
 poppler-data
-postgresql-client-11
+postgresql-client-12
 postgresql-client-common
 procps
 python


### PR DESCRIPTION
This undoes the pinning of `libpq` added in #148 and additionally updates `postgresql-client` and `postgresql-server-dev` to the PG12 releases, to support Heroku Postgres 12.

Since #148 the upstream Postgres project has improved the libpq 12 error handling, such that it now provides a clearer error message when the validation of connection parameters fail, which makes it easier for customers to identify that it's due to their app having an invalid configuration.

The build scripts for Cedar-14 have not been modified since the upstream Postgres project has not released PG12 versions of the packages for Ubuntu-14 given it is EOL.

Release notes:
https://www.postgresql.org/docs/12/release-12.html

Refs [W-7113082](https://gus.lightning.force.com/lightning/r/ADM_Work__c/a07B0000007sgomIAA/view).
Closes #147.