### PR TITLE
Update Heroku-20 installed packages list

### DIFF
--- a/heroku-20-build/installed-packages.txt
+++ b/heroku-20-build/installed-packages.txt
@@ -99,7 +99,6 @@ lib32stdc++6
 libacl1
 libacl1-dev
 libapt-pkg-dev
-libapt-pkg5.90
 libapt-pkg6.0
 libarchive13
 libargon2-1
@@ -551,7 +550,6 @@ rename
 rsync
 ruby
 ruby-dev
-ruby-did-you-mean
 ruby-minitest
 ruby-net-telnet
 ruby-power-assert

--- a/heroku-20/installed-packages.txt
+++ b/heroku-20/installed-packages.txt
@@ -70,7 +70,6 @@ language-pack-en
 language-pack-en-base
 less
 libacl1
-libapt-pkg5.90
 libapt-pkg6.0
 libargon2-1
 libasan5
@@ -321,7 +320,6 @@ readline-common
 rename
 rsync
 ruby
-ruby-did-you-mean
 ruby-minitest
 ruby-net-telnet
 ruby-power-assert


### PR DESCRIPTION
Between the Ubuntu 20.04 release candidate and final release, some packages are now no longer installed, which causes CI to fail:
https://travis-ci.org/github/heroku/stack-images/jobs/678935475

The `libapt-pkg5.90` package was previously in the base Ubuntu image, and the `ruby-did-you-mean` package was a `depends` of `libruby2.7`.

Neither are required, and Heroku-20 is currently not released, so we do not need to explicitly install them to maintain the installed packages list as it was.

The installed packages lists were regenerated using `bin/build.sh`:
https://github.com/heroku/stack-images/blob/master/BUILD.md

Refs [W-7489616](https://gus.lightning.force.com/lightning/r/ADM_Work__c/a07B0000008NoqzIAC/view).