### PR TITLE
Only publish Docker images on master/tags

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -26,5 +26,5 @@ deploy:
     script: sh bin/publish-to-dockerhub.sh
     on:
       # Cedar-14 images must not be published to Docker Hub since they contain ESM updates.
-      condition: $STACK != "cedar-14"
+      condition: ($TRAVIS_BRANCH == "master" || -n $TRAVIS_TAG) && $STACK != "cedar-14"
       all_branches: true


### PR DESCRIPTION
Before images were published to the nightly/date-versioned tags for feature branches, and not just master/tags. This makes CI take longer, creates more Docker repo churn, and means consumers of the nightly tags could end up with unexpected changes from feature branches.

If testing of feature branches is required, images can be easily built locally, or tags can be manually pushed.

The `TRAVIS_BRANCH` env var is being used inside the condition along with `all_branches: true`, since for tags Travis overwrites the branch with the tag name, meaning `branches: master` would exclude tags too. See travis-ci/travis-ci/issues/7780.

I've tested this conditional on another repository for master/feature branches/tags and it works.

Refs [W-7496420](https://gus.lightning.force.com/lightning/r/ADM_Work__c/a07B0000008Nuk5IAC/view).