### PR TITLE
Move remaining Dockerfile env vars and commands into setup.sh

### DIFF
--- a/cedar-14/Dockerfile
+++ b/cedar-14/Dockerfile
@@ -2,5 +2,4 @@ FROM ubuntu-debootstrap:14.04
 ARG ESM_USERNAME
 ARG ESM_PASSWORD
 COPY setup.sh /tmp/setup.sh
-RUN LC_ALL=C DEBIAN_FRONTEND=noninteractive /tmp/setup.sh \
-  && rm -rf /var/lib/apt/lists/*
+RUN /tmp/setup.sh

--- a/cedar-14/setup.sh
+++ b/cedar-14/setup.sh
@@ -4,6 +4,9 @@ exec 2>&1
 set -e
 set -x
 
+export DEBIAN_FRONTEND=noninteractive
+export LC_ALL=C
+
 cat > /etc/apt/sources.list <<EOF
 deb http://archive.ubuntu.com/ubuntu/ trusty main universe
 deb http://archive.ubuntu.com/ubuntu/ trusty-security main universe
@@ -260,11 +263,11 @@ cat > /etc/ImageMagick/policy.xml <<'IMAGEMAGICK_POLICY'
 </policymap>
 IMAGEMAGICK_POLICY
 
-cd /
 rm -r "${APT_AUTH_CONFIG_DIR}"
-rm -rf /var/cache/apt/archives/*.deb
 rm -rf /root/*
 rm -rf /tmp/*
+rm -rf /var/cache/apt/archives/*.deb
+rm -rf /var/lib/apt/lists/*
 
 # Sanity check that we cleaned up the ESM credentials correctly.
 # xtrace is disabled in the subshell to prevent the password from ending up in the logs.

--- a/heroku-16-build/Dockerfile
+++ b/heroku-16-build/Dockerfile
@@ -1,4 +1,3 @@
 FROM heroku/heroku:16
 COPY setup.sh /tmp/setup.sh
-RUN LC_ALL=C DEBIAN_FRONTEND=noninteractive /tmp/setup.sh \
-  && rm -rf /var/lib/apt/lists/*
+RUN /tmp/setup.sh

--- a/heroku-16-build/setup.sh
+++ b/heroku-16-build/setup.sh
@@ -4,6 +4,9 @@ exec 2>&1
 set -e
 set -x
 
+export DEBIAN_FRONTEND=noninteractive
+export LC_ALL=C
+
 apt-get update
 apt-get install -y --force-yes \
     autoconf \
@@ -77,7 +80,7 @@ apt-get install -y --force-yes \
     ruby-dev \
     zlib1g-dev \
 
-cd /
 rm -rf /root/*
 rm -rf /tmp/*
 rm -rf /var/cache/apt/archives/*.deb
+rm -rf /var/lib/apt/lists/*

--- a/heroku-16/Dockerfile
+++ b/heroku-16/Dockerfile
@@ -1,4 +1,3 @@
 FROM ubuntu:16.04
 COPY setup.sh /tmp/setup.sh
-RUN LC_ALL=C DEBIAN_FRONTEND=noninteractive /tmp/setup.sh \
-  && rm -rf /var/lib/apt/lists/*
+RUN /tmp/setup.sh

--- a/heroku-16/setup.sh
+++ b/heroku-16/setup.sh
@@ -4,6 +4,9 @@ exec 2>&1
 set -e
 set -x
 
+export DEBIAN_FRONTEND=noninteractive
+export LC_ALL=C
+
 cat > /etc/apt/sources.list <<EOF
 deb http://archive.ubuntu.com/ubuntu/ xenial main universe
 deb http://archive.ubuntu.com/ubuntu/ xenial-security main universe
@@ -172,7 +175,7 @@ cat > /etc/ImageMagick-6/policy.xml <<'IMAGEMAGICK_POLICY'
 </policymap>
 IMAGEMAGICK_POLICY
 
-cd /
 rm -rf /root/*
 rm -rf /tmp/*
 rm -rf /var/cache/apt/archives/*.deb
+rm -rf /var/lib/apt/lists/*

--- a/heroku-18-build/Dockerfile
+++ b/heroku-18-build/Dockerfile
@@ -1,4 +1,3 @@
 FROM heroku/heroku:18
 COPY setup.sh /tmp/setup.sh
-RUN LC_ALL=C DEBIAN_FRONTEND=noninteractive /tmp/setup.sh \
-  && rm -rf /var/lib/apt/lists/*
+RUN /tmp/setup.sh

--- a/heroku-18-build/setup.sh
+++ b/heroku-18-build/setup.sh
@@ -4,6 +4,9 @@ exec 2>&1
 set -e
 set -x
 
+export DEBIAN_FRONTEND=noninteractive
+export LC_ALL=C
+
 apt-get update
 apt-get install -y --force-yes --no-install-recommends \
     autoconf \
@@ -80,7 +83,7 @@ apt-get install -y --force-yes --no-install-recommends \
     ruby-dev \
     zlib1g-dev \
 
-cd /
 rm -rf /root/*
 rm -rf /tmp/*
 rm -rf /var/cache/apt/archives/*.deb
+rm -rf /var/lib/apt/lists/*

--- a/heroku-18/Dockerfile
+++ b/heroku-18/Dockerfile
@@ -1,4 +1,3 @@
 FROM ubuntu:18.04
 COPY setup.sh /tmp/setup.sh
-RUN LC_ALL=C DEBIAN_FRONTEND=noninteractive /tmp/setup.sh \
-  && rm -rf /var/lib/apt/lists/*
+RUN /tmp/setup.sh

--- a/heroku-18/setup.sh
+++ b/heroku-18/setup.sh
@@ -4,6 +4,9 @@ exec 2>&1
 set -e
 set -x
 
+export DEBIAN_FRONTEND=noninteractive
+export LC_ALL=C
+
 cat >/etc/apt/sources.list <<EOF
 deb http://archive.ubuntu.com/ubuntu/ bionic main universe
 deb http://archive.ubuntu.com/ubuntu/ bionic-security main universe
@@ -212,7 +215,7 @@ apt-get -y --purge autoremove
 apt-get purge -y openjdk-8-jre-headless
 test "$(file -b /etc/ssl/certs/java/cacerts)" = "Java KeyStore"
 
-cd /
 rm -rf /root/*
 rm -rf /tmp/*
 rm -rf /var/cache/apt/archives/*.deb
+rm -rf /var/lib/apt/lists/*

--- a/heroku-20-build/Dockerfile
+++ b/heroku-20-build/Dockerfile
@@ -1,4 +1,3 @@
 FROM heroku/heroku:20
 COPY setup.sh /tmp/setup.sh
-RUN LC_ALL=C DEBIAN_FRONTEND=noninteractive /tmp/setup.sh \
-  && rm -rf /var/lib/apt/lists/*
+RUN /tmp/setup.sh

--- a/heroku-20-build/setup.sh
+++ b/heroku-20-build/setup.sh
@@ -4,6 +4,9 @@ exec 2>&1
 set -e
 set -x
 
+export DEBIAN_FRONTEND=noninteractive
+export LC_ALL=C
+
 apt-get update
 apt-get install -y --force-yes --no-install-recommends \
     autoconf \
@@ -80,7 +83,7 @@ apt-get install -y --force-yes --no-install-recommends \
     ruby-dev \
     zlib1g-dev \
 
-cd /
 rm -rf /root/*
 rm -rf /tmp/*
 rm -rf /var/cache/apt/archives/*.deb
+rm -rf /var/lib/apt/lists/*

--- a/heroku-20/Dockerfile
+++ b/heroku-20/Dockerfile
@@ -1,4 +1,3 @@
 FROM ubuntu:20.04
 COPY setup.sh /tmp/setup.sh
-RUN LC_ALL=C DEBIAN_FRONTEND=noninteractive /tmp/setup.sh \
-  && rm -rf /var/lib/apt/lists/*
+RUN /tmp/setup.sh

--- a/heroku-20/setup.sh
+++ b/heroku-20/setup.sh
@@ -4,6 +4,9 @@ exec 2>&1
 set -e
 set -x
 
+export DEBIAN_FRONTEND=noninteractive
+export LC_ALL=C
+
 cat >/etc/apt/sources.list <<EOF
 deb http://archive.ubuntu.com/ubuntu/ focal main universe
 deb http://archive.ubuntu.com/ubuntu/ focal-security main universe
@@ -212,7 +215,7 @@ apt-get -y --purge autoremove
 apt-get purge -y openjdk-8-jre-headless
 test "$(file -b /etc/ssl/certs/java/cacerts)" = "Java KeyStore"
 
-cd /
 rm -rf /root/*
 rm -rf /tmp/*
 rm -rf /var/cache/apt/archives/*.deb
+rm -rf /var/lib/apt/lists/*


### PR DESCRIPTION
So that everything is in one place, both for humans (it's otherwise easy to think that the APT lists aren't being cleaned up when just looking at `setup.sh`) and for potential future usage of shellcheck (which will only be able to scan the scripts, not the Dockerfiles).

The `cd /` prior to the cleanup steps has also been removed, as it's not necessary (we neither change working directory from `/`, nor does the current working directory ever block use of `rm`).

Refs [W-7496420](https://gus.lightning.force.com/lightning/r/ADM_Work__c/a07B0000008Nuk5IAC/view).