### PR TITLE
Update Travis CI environment from Ubuntu 14.04 to 20.04

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,5 +1,4 @@
-sudo: required
-dist: trusty
+dist: focal
 language: shell
 services:
 - docker


### PR DESCRIPTION
Since 14.04 is EOL. Travis' default is now `xenial`, but there's both `bionic` and `focal` available if we request them specifically. (The latter not yet being fully documented, but still usable and saves us having to bump again shortly.)

The `sudo: required` line was removed since it's the default now that Travis no longer supports its rootless container infrastructure.

See:
https://docs.travis-ci.com/user/reference/linux/

Refs [W-7496420](https://gus.lightning.force.com/lightning/r/ADM_Work__c/a07B0000008Nuk5IAC/view).