### PR TITLE
Run the docker login command more safely

### DIFF
--- a/bin/publish-to-dockerhub.sh
+++ b/bin/publish-to-dockerhub.sh
@@ -15,7 +15,8 @@ dateBuildTag="${PRIVATE_IMAGE_TAG}-build.${date}"
 
 bin/build.sh $STACK $nightlyTag $nightlyBuildTag
 
-docker login -u $DOCKER_HUB_USERNAME -p $DOCKER_HUB_PASSWORD
+# Disable tracing temporarily to prevent logging DOCKER_HUB_PASSWORD.
+(set +x; echo "${$DOCKER_HUB_PASSWORD}" | docker login -u "${DOCKER_HUB_USERNAME}" --password-stdin)
 
 docker push $nightlyTag
 


### PR DESCRIPTION
Previously tracing mode meant that the Docker credentials were output to stderr during the image publishing step. Travis strips secrets set via Travis env vars from the logs (replacing the text with `[secure]`), so these weren't visible, but it's safer to just not output them at all.

The command is now run in a sub-shell (saves having to re-enable tracing after), with tracing disabled.

In addition, Docker [recommends](https://docs.docker.com/engine/reference/commandline/login/#provide-a-password-using-stdin) using `--password-stdin` over `--password` since the former doesn't result in the credentials being added to bash history (not that this is really relevant in CI, but it stops the warning anyway).

Travis logs before:

```
+bin/build.sh heroku-18 heroku/heroku:18.nightly heroku/heroku:18-build.nightly
...
+docker login -u [secure] -p [secure]
WARNING! Using --password via the CLI is insecure. Use --password-stdin.
Login Succeeded
+docker push heroku/heroku:18.nightly
```

Travis logs after:

```
+bin/build.sh heroku-18 heroku/heroku:18.nightly heroku/heroku:18-build.nightly
...
+ set +x
Login Succeeded
+docker push heroku/heroku:18.nightly
```

Refs [W-7496420](https://gus.lightning.force.com/lightning/r/ADM_Work__c/a07B0000008Nuk5IAC/view).