### PR TITLE
Fix typo in publish-to-dockerhub.sh

### DIFF
--- a/bin/publish-to-dockerhub.sh
+++ b/bin/publish-to-dockerhub.sh
@@ -16,7 +16,7 @@ dateBuildTag="${PRIVATE_IMAGE_TAG}-build.${date}"
 bin/build.sh $STACK $nightlyTag $nightlyBuildTag
 
 # Disable tracing temporarily to prevent logging DOCKER_HUB_PASSWORD.
-(set +x; echo "${$DOCKER_HUB_PASSWORD}" | docker login -u "${DOCKER_HUB_USERNAME}" --password-stdin)
+(set +x; echo "${DOCKER_HUB_PASSWORD}" | docker login -u "${DOCKER_HUB_USERNAME}" --password-stdin)
 
 docker push $nightlyTag
 


### PR DESCRIPTION
Follow-up to #160. I'd fixed this locally but not `git add`ed the change - doh!

This would have been caught by shellcheck, were we running it in CI:

```sh
In ./bin/publish-to-dockerhub.sh line 19:
(set +x; echo "${$DOCKER_HUB_PASSWORD}" | docker login -u "${DOCKER_HUB_USERNAME}" --password-stdin)
               ^---------------------^ SC2082: To expand via indirection, use arrays, ${!name} or (for sh only) eval.

```