### PR TITLE
Run shellcheck in CI

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -9,6 +9,7 @@ env:
   - STACK=heroku-18 IMAGE_TAG=heroku/heroku:18 PRIVATE_IMAGE_TAG=heroku/heroku-private:18
   - STACK=heroku-20 IMAGE_TAG=heroku/heroku:20 PRIVATE_IMAGE_TAG=heroku/heroku-private:20
 script:
+- find . -type f \( -name "*.sh" -o -path "*/bin/*" \) ! -name '*.jq' | xargs -t shellcheck
 - bin/build.sh $STACK $IMAGE_TAG $IMAGE_TAG-build
 - |
   status="$(git status --porcelain)"
@@ -22,7 +23,7 @@ deploy:
     on:
       tags: true
   - provider: script
-    script: sh bin/publish-to-dockerhub.sh
+    script: bin/publish-to-dockerhub.sh
     on:
       # Cedar-14 images must not be published to Docker Hub since they contain ESM updates.
       condition: ($TRAVIS_BRANCH == "master" || -n $TRAVIS_TAG) && $STACK != "cedar-14"

--- a/bin/build.sh
+++ b/bin/build.sh
@@ -5,16 +5,16 @@ set -euo pipefail
 cd "$(dirname "${BASH_SOURCE[0]}")/.."
 . bin/stack-helpers.sh
 
-[ $# -eq 3 ] || abort usage: $(basename "${BASH_SOURCE[0]}") STACK IMAGE_NAME BUILD_IMAGE_NAME
+[ $# -eq 3 ] || abort "usage: $(basename "${BASH_SOURCE[0]}") STACK IMAGE_NAME BUILD_IMAGE_NAME"
 
 STACK=$1
 IMAGE_TAG=$2
 BUILD_IMAGE_TAG=$3
 DOCKERFILE_DIR="$STACK"
 
-echo $DOCKERFILE_DIR
+echo "${DOCKERFILE_DIR}"
 
-[[ -d "$DOCKERFILE_DIR" ]] || abort fatal: stack "$STACK" not found
+[[ -d "${DOCKERFILE_DIR}" ]] || abort "fatal: stack ${STACK} not found"
 
 write_package_list() {
     local image_tag="$1"

--- a/bin/convert-and-publish-to-heroku.sh
+++ b/bin/convert-and-publish-to-heroku.sh
@@ -1,4 +1,6 @@
-#!/bin/sh
+#!/usr/bin/env bash
+
+set -euo pipefail
 
 sudo cp tools/bin/* /usr/local/bin
-sudo convert-to-heroku-stack-image $STACK
+sudo convert-to-heroku-stack-image "${STACK}"

--- a/bin/publish-to-dockerhub.sh
+++ b/bin/publish-to-dockerhub.sh
@@ -1,6 +1,7 @@
-#!/bin/sh
+#!/usr/bin/env bash
 
-set -ex
+set -euo pipefail
+set -x
 
 if [ "${STACK}" = 'cedar-14' ]; then
   echo 'Error: Publishing cedar-14 images to Docker Hub is no longer permitted, since they contain ESM updates.'
@@ -9,25 +10,25 @@ fi
 
 nightlyTag="${IMAGE_TAG}.nightly"
 nightlyBuildTag="${IMAGE_TAG}-build.nightly"
-date=`date -u '+%Y-%m-%d-%H.%M.%S'`
+date=$(date -u '+%Y-%m-%d-%H.%M.%S')
 dateTag="${PRIVATE_IMAGE_TAG}.${date}"
 dateBuildTag="${PRIVATE_IMAGE_TAG}-build.${date}"
 
-bin/build.sh $STACK $nightlyTag $nightlyBuildTag
+bin/build.sh "${STACK}" "${nightlyTag}" "${nightlyBuildTag}"
 
 # Disable tracing temporarily to prevent logging DOCKER_HUB_PASSWORD.
 (set +x; echo "${DOCKER_HUB_PASSWORD}" | docker login -u "${DOCKER_HUB_USERNAME}" --password-stdin)
 
-docker push $nightlyTag
+docker push "${nightlyTag}"
 
-docker tag $nightlyTag $dateTag
-docker push $dateTag
+docker tag "${nightlyTag}" "${dateTag}"
+docker push "${dateTag}"
 
 if [ "$STACK" != "cedar-14" ]; then
-  docker push $nightlyBuildTag
+  docker push "${nightlyBuildTag}"
 
-  docker tag $nightlyBuildTag $dateBuildTag
-  docker push $dateBuildTag
+  docker tag "${nightlyBuildTag}" "${dateBuildTag}"
+  docker push "${dateBuildTag}"
 fi
 
 if [ -n "$TRAVIS_TAG" ]; then
@@ -36,20 +37,20 @@ if [ -n "$TRAVIS_TAG" ]; then
   latestTag="${IMAGE_TAG}"
   latestBuildTag="${IMAGE_TAG}-build"
 
-  docker tag $nightlyTag $releaseTag
-  docker tag $nightlyTag $latestTag
+  docker tag "${nightlyTag}" "${releaseTag}"
+  docker tag "${nightlyTag}" "${latestTag}"
 
-  docker push $releaseTag
-  docker push $latestTag
+  docker push "${releaseTag}"
+  docker push "${latestTag}"
 
   if [ "$STACK" != "cedar-14" ]; then
-    docker tag $nightlyBuildTag $releaseBuildTag
-    docker tag $nightlyBuildTag $latestBuildTag
+    docker tag "${nightlyBuildTag}" "${releaseBuildTag}"
+    docker tag "${nightlyBuildTag}" "${latestBuildTag}"
 
-    docker push $releaseBuildTag
-    docker push $latestBuildTag
+    docker push "${releaseBuildTag}"
+    docker push "${latestBuildTag}"
   else
-    docker tag $nightlyTag heroku/cedar:latest
+    docker tag "${nightlyTag}" heroku/cedar:latest
     docker push heroku/cedar:latest
   fi
 fi

--- a/bin/stack-helpers.sh
+++ b/bin/stack-helpers.sh
@@ -1,11 +1,12 @@
-set -o pipefail
+# shellcheck shell=bash
 
 function display() {
-  echo -e "\n----->" $*
+  echo -e "\n-----> $1"
 }
 
 function abort() {
-  echo $* ; exit 1
+  echo "$1"
+  exit 1
 }
 
 function indent() {

--- a/cedar-14/setup.sh
+++ b/cedar-14/setup.sh
@@ -1,7 +1,8 @@
-#!/bin/bash
+#!/usr/bin/env bash
+
+set -euo pipefail
 
 exec 2>&1
-set -e
 set -x
 
 export DEBIAN_FRONTEND=noninteractive
@@ -278,7 +279,7 @@ fi
 
 # remove SUID and SGID flags from all binaries
 function pruned_find() {
-  find / -type d \( -name dev -o -name proc \) -prune -o $@ -print
+  find / -type d \( -name dev -o -name proc \) -prune -o "$@" -print
 }
 
 pruned_find -perm /u+s | xargs -r chmod u-s
@@ -306,4 +307,3 @@ echo -e "\nInstalled versions:"
 ) 2>&1 | sed "s/^/  /"
 
 echo -e "\nSuccess!"
-exit 0

--- a/heroku-16-build/setup.sh
+++ b/heroku-16-build/setup.sh
@@ -1,7 +1,8 @@
-#!/bin/bash
+#!/usr/bin/env bash
+
+set -euo pipefail
 
 exec 2>&1
-set -e
 set -x
 
 export DEBIAN_FRONTEND=noninteractive

--- a/heroku-16/setup.sh
+++ b/heroku-16/setup.sh
@@ -1,7 +1,8 @@
-#!/bin/bash
+#!/usr/bin/env bash
+
+set -euo pipefail
 
 exec 2>&1
-set -e
 set -x
 
 export DEBIAN_FRONTEND=noninteractive

--- a/heroku-18-build/setup.sh
+++ b/heroku-18-build/setup.sh
@@ -1,7 +1,8 @@
-#!/bin/bash
+#!/usr/bin/env bash
+
+set -euo pipefail
 
 exec 2>&1
-set -e
 set -x
 
 export DEBIAN_FRONTEND=noninteractive

--- a/heroku-18/setup.sh
+++ b/heroku-18/setup.sh
@@ -1,7 +1,8 @@
-#!/bin/bash
+#!/usr/bin/env bash
+
+set -euo pipefail
 
 exec 2>&1
-set -e
 set -x
 
 export DEBIAN_FRONTEND=noninteractive

--- a/heroku-20-build/setup.sh
+++ b/heroku-20-build/setup.sh
@@ -1,7 +1,8 @@
-#!/bin/bash
+#!/usr/bin/env bash
+
+set -euo pipefail
 
 exec 2>&1
-set -e
 set -x
 
 export DEBIAN_FRONTEND=noninteractive

--- a/heroku-20/setup.sh
+++ b/heroku-20/setup.sh
@@ -1,7 +1,8 @@
-#!/bin/bash
+#!/usr/bin/env bash
+
+set -euo pipefail
 
 exec 2>&1
-set -e
 set -x
 
 export DEBIAN_FRONTEND=noninteractive

--- a/tools/bin/abort
+++ b/tools/bin/abort
@@ -1,6 +1,6 @@
-#!/bin/bash
+#!/usr/bin/env bash
 
-set -e
+set -euo pipefail
 
 echo "$@"
 exit 1

--- a/tools/bin/capture-docker-stack
+++ b/tools/bin/capture-docker-stack
@@ -1,16 +1,16 @@
-#!/bin/bash
+#!/usr/bin/env bash
 
-set -e -o pipefail
+set -euo pipefail
 
-[ $# -ge 1 ] || abort usage: $(basename $0) STACK [VERSION]
-[ $UID = 0 ] || abort fatal: must be called with sudo
+[ $# -ge 1 ] || abort "usage: $(basename "$0") STACK [VERSION]"
+[ $UID = 0 ] || abort "fatal: must be called with sudo"
 
 STACK=$1
-STACK_NAME=$(echo $STACK | cut -d '-' -f 1)
-STACK_VERSION=$(echo $STACK | cut -d '-' -f 2-)
+STACK_NAME=$(echo "${STACK}" | cut -d '-' -f 1)
+STACK_VERSION=$(echo "${STACK}" | cut -d '-' -f 2-)
 
 DOCKER_IMAGE=heroku/$STACK_NAME:$STACK_VERSION
-DOCKER_IMAGE_VERSION=$(docker inspect $DOCKER_IMAGE | jq .[].Id | cut -d ':' -f 2 | cut -b 1-12)
+DOCKER_IMAGE_VERSION=$(docker inspect "${DOCKER_IMAGE}" | jq .[].Id | cut -d ':' -f 2 | cut -b 1-12)
 
 IMG_BASE=${STACK_NAME}64-$STACK_VERSION-$DOCKER_IMAGE_VERSION
 IMG=/tmp/$IMG_BASE.img
@@ -20,35 +20,35 @@ IMG_SHA256=/tmp/$IMG_BASE.img.sha256
 IMG_MANIFEST=/tmp/$IMG_BASE.manifest
 IMG_PKG_VERSIONS=/tmp/$IMG_BASE.pkg.versions
 
-display Starting capture for $STACK $DOCKER_IMAGE_VERSION at $(date)
+display "Starting capture for ${STACK} ${DOCKER_IMAGE_VERSION} at $(date)"
 
-display Creating image file $IMG
-make-filesystem-image $IMG |& indent
+display "Creating image file ${IMG}"
+make-filesystem-image "${IMG}" |& indent
 
-display Mounting image $IMG_MNT
-mount-filesystem-image $IMG $IMG_MNT |& indent
+display "Mounting image ${IMG_MNT}"
+mount-filesystem-image "${IMG}" "${IMG_MNT}" |& indent
 
-display Copying stack to image
-export-docker-image $DOCKER_IMAGE $IMG_MNT |& indent
+display "Copying stack to image"
+export-docker-image "${DOCKER_IMAGE}" "${IMG_MNT}" |& indent
 
-display Modifying image directories and files
-install-heroku-files $IMG_MNT |& indent
+display "Modifying image directories and files"
+install-heroku-files "${IMG_MNT}" |& indent
 
-display Unmounting image
-umount $IMG_MNT |& indent
+display "Unmounting image"
+umount "${IMG_MNT}" |& indent
 
-display SHA256ing and gzipping image
-make-image-archive $IMG $IMG_SHA256 |& indent
-cat $IMG_SHA256
+display "SHA256ing and gzipping image"
+make-image-archive "${IMG}" "${IMG_SHA256}" |& indent
+cat "${IMG_SHA256}"
 
 if update-manifest; then
-    display Starting push at $(date)
-    display Capture Package Versions
-    capture-package-versions $DOCKER_IMAGE $IMG_PKG_VERSIONS
-    display Uploading files
-    upload-image $IMG_GZ $IMG_SHA256 $IMG_MANIFEST $STACK $DOCKER_IMAGE_VERSION $IMG_PKG_VERSIONS |& indent
+    display "Starting push at $(date)"
+    display "Capture Package Versions"
+    capture-package-versions "${DOCKER_IMAGE}" "${IMG_PKG_VERSIONS}"
+    display "Uploading files"
+    upload-image "${IMG_GZ}" "${IMG_SHA256}" "${IMG_MANIFEST}" "${STACK}" "${DOCKER_IMAGE_VERSION}" "${IMG_PKG_VERSIONS}" |& indent
 else
-    display Skipping image upload
+    display "Skipping image upload"
 fi
 
-display Finished capture for $STACK $DOCKER_IMAGE_VERSION
+display "Finished capture for ${STACK} ${DOCKER_IMAGE_VERSION}"

--- a/tools/bin/capture-package-versions
+++ b/tools/bin/capture-package-versions
@@ -1,8 +1,8 @@
-#!/bin/bash
+#!/usr/bin/env bash
 
-set -e -o pipefail
+set -euo pipefail
 
 DOCKER_IMAGE=$1
 OUTPUT_FILE=$2
 
-docker run --rm -ti $DOCKER_IMAGE dpkg-query -W -f "\${package},\${version}\n" | jq -s -R -f /usr/local/bin/csv-to-array.jq > $OUTPUT_FILE
+docker run --rm -ti "${DOCKER_IMAGE}" dpkg-query -W -f "\${package},\${version}\n" | jq -s -R -f /usr/local/bin/csv-to-array.jq > "${OUTPUT_FILE}"

--- a/tools/bin/convert-to-heroku-stack-image
+++ b/tools/bin/convert-to-heroku-stack-image
@@ -1,6 +1,7 @@
-#!/bin/bash
+#!/usr/bin/env bash
 
-set -e -o pipefail
+set -euo pipefail
+
 VERSION_PREFIX=$(date '+%Y%m%d-%H%M%S')
 
 while [ $# -gt 0 ]; do
@@ -17,8 +18,8 @@ while [ $# -gt 0 ]; do
 done
 
 if update-manifest; then
-  display Publishing manifest update
+  display "Publishing manifest update"
   publish-manifests
 else
-  display Skipping manifest update
+  display "Skipping manifest update"
 fi

--- a/tools/bin/display
+++ b/tools/bin/display
@@ -1,5 +1,5 @@
-#!/bin/bash
+#!/usr/bin/env bash
 
-set -e
+set -euo pipefail
 
 exec echo $'\n----->' "$@"

--- a/tools/bin/docker-entrypoint
+++ b/tools/bin/docker-entrypoint
@@ -1,4 +1,5 @@
-#!/bin/bash
+#!/usr/bin/env bash
 
-set -e -o pipefail
+set -euo pipefail
+
 convert-to-heroku-stack-image "$@"

--- a/tools/bin/export-docker-image
+++ b/tools/bin/export-docker-image
@@ -1,6 +1,6 @@
-#!/bin/bash
+#!/usr/bin/env bash
 
-set -e
+set -euo pipefail
 
 DOCKER_IMAGE="$1"
 MNT="$2"

--- a/tools/bin/indent
+++ b/tools/bin/indent
@@ -1,5 +1,5 @@
-#!/bin/bash
+#!/usr/bin/env bash
 
-set -e
+set -euo pipefail
 
 exec sed -u "s/^/       /"

--- a/tools/bin/install-heroku-files
+++ b/tools/bin/install-heroku-files
@@ -1,6 +1,6 @@
-#!/bin/bash
+#!/usr/bin/env bash
 
-set -e
+set -euo pipefail
 
 IMG_MNT="$1"
 

--- a/tools/bin/make-filesystem-image
+++ b/tools/bin/make-filesystem-image
@@ -1,10 +1,10 @@
-#!/bin/bash
+#!/usr/bin/env bash
 
-set -e
+set -euo pipefail
 
 IMG="$1"
 
 mkdir -p "$(dirname "$IMG")"
 dd if=/dev/zero of="$IMG" bs=100M count=24
-yes | mkfs -t ext3 -m 1 "$IMG"
+mkfs -t ext3 -m 1 "$IMG"
 tune2fs -c 0 -i 0 "$IMG"

--- a/tools/bin/make-image-archive
+++ b/tools/bin/make-image-archive
@@ -1,6 +1,6 @@
-#!/bin/bash
+#!/usr/bin/env bash
 
-set -e
+set -euo pipefail
 
 IMG="$1"
 IMG_SHA256="$2"

--- a/tools/bin/mount-filesystem-image
+++ b/tools/bin/mount-filesystem-image
@@ -1,6 +1,6 @@
-#!/bin/bash
+#!/usr/bin/env bash
 
-set -e
+set -euo pipefail
 
 IMG="$1"
 IMG_MNT="$2"

--- a/tools/bin/publish-manifests
+++ b/tools/bin/publish-manifests
@@ -1,6 +1,6 @@
-#!/bin/bash
+#!/usr/bin/env bash
 
-set -e
+set -euo pipefail
 
 if ls /tmp/*64-*.manifest >& /dev/null; then
     jq --null-input \

--- a/tools/bin/update-manifest
+++ b/tools/bin/update-manifest
@@ -1,8 +1,6 @@
-#!/bin/bash
+#!/usr/bin/env bash
 
-set -e
+set -euo pipefail
 
-[ -z "$MANIFEST_APP_URL" ] && echo "Missing manifest app url" && exit 1
-[ -z "$MANIFEST_APP_TOKEN" ] && echo "Missing manifest app token" && exit 1
-
-exit 0
+[[ -v MANIFEST_APP_URL ]] || { echo "Missing manifest app url" && exit 1; }
+[[ -v MANIFEST_APP_TOKEN ]] || { echo "Missing manifest app token" && exit 1; }

--- a/tools/bin/upload-image
+++ b/tools/bin/upload-image
@@ -1,6 +1,6 @@
-#!/bin/bash
+#!/usr/bin/env bash
 
-set -e
+set -euo pipefail
 
 IMG_GZ="$1"
 IMG_SHA256="$2"
@@ -9,12 +9,12 @@ STACK=$4
 VERSION="$5"
 IMG_PKG_VERSIONS="$6"
 
-display Creating Image on $MANIFEST_APP_URL
+display "Creating Image on ${MANIFEST_APP_URL}"
 
 jq \
     --null-input \
     --arg stack "$STACK" \
-    --slurpfile packages $IMG_PKG_VERSIONS \
+    --slurpfile packages "${IMG_PKG_VERSIONS}" \
     --arg version "$VERSION" \
     --arg sha "$(< "$IMG_SHA256")" \
     '{
@@ -30,13 +30,13 @@ jq \
         --header "Content-Type: application/json" \
         --data @- \
         "$MANIFEST_APP_URL/images" |
-    jq > $IMG_MANIFEST \
+    jq > "${IMG_MANIFEST}" \
         --arg name "$STACK" \
         '{
             name: $name
         } + .'
 
-display Uploading Image to S3
+display "Uploading Image to S3"
 PUT_URL=$(jq -r .put_url "$IMG_MANIFEST")
 curl \
     --silent --show-error \


### PR DESCRIPTION
Shellcheck lints shell scripts, helping to prevent common mistakes:
https://github.com/koalaman/shellcheck#gallery-of-bad-code

It would have caught the typo that was fixed in #161.

In order for shellcheck to pass, the following needed fixing:

- ```SC2006: Use $(...) notation instead of legacy backticks `...`.```
          -> https://www.shellcheck.net/wiki/SC2006
- `SC2046: Quote this to prevent word splitting.`
          -> https://www.shellcheck.net/wiki/SC2046
- `SC2048: Use "$@" (with quotes) to prevent whitespace problems.`
          -> https://www.shellcheck.net/wiki/SC2048
- `SC2068: Double quote array expansions to avoid re-splitting elements.`
          -> https://www.shellcheck.net/wiki/SC2068
- `SC2086: Double quote to prevent globbing and word splitting.`
          -> https://www.shellcheck.net/wiki/SC2086

All non-sourced scripts have also been updated to use stricter bash modes:
http://redsymbol.net/articles/unofficial-bash-strict-mode/

These changes were tested by manually triggering another Heroku-20 Docker+stack image release on an adhoc branch (since PRs/master don't run all steps):
https://travis-ci.com/github/heroku/stack-images/jobs/324852938

Refs [W-7496420](https://gus.lightning.force.com/lightning/r/ADM_Work__c/a07B0000008Nuk5IAC/view).