### PR TITLE
Stop using --force-yes with apt-get on newer stacks

### DIFF
--- a/heroku-16-build/setup.sh
+++ b/heroku-16-build/setup.sh
@@ -9,7 +9,7 @@ export DEBIAN_FRONTEND=noninteractive
 export LC_ALL=C
 
 apt-get update
-apt-get install -y --force-yes \
+apt-get install -y \
     autoconf \
     bison \
     build-essential \

--- a/heroku-16/setup.sh
+++ b/heroku-16/setup.sh
@@ -97,8 +97,8 @@ Gtz3cydIohvNO9d90+29h0eGEDYti7j7maHkBKUAwlcPvMg5m3Y=
 PGDG_ACCC4CF8
 
 apt-get update
-apt-get upgrade -y --force-yes
-apt-get install -y --force-yes \
+apt-get upgrade -y
+apt-get install -y \
     apt-transport-https \
     apt-utils \
     bind9-host \

--- a/heroku-18-build/setup.sh
+++ b/heroku-18-build/setup.sh
@@ -9,7 +9,7 @@ export DEBIAN_FRONTEND=noninteractive
 export LC_ALL=C
 
 apt-get update
-apt-get install -y --force-yes --no-install-recommends \
+apt-get install -y --no-install-recommends \
     autoconf \
     automake \
     bison \

--- a/heroku-20-build/setup.sh
+++ b/heroku-20-build/setup.sh
@@ -9,7 +9,7 @@ export DEBIAN_FRONTEND=noninteractive
 export LC_ALL=C
 
 apt-get update
-apt-get install -y --force-yes --no-install-recommends \
+apt-get install -y --no-install-recommends \
     autoconf \
     automake \
     bison \


### PR DESCRIPTION
Since as of APT 1.1 (Ubuntu 16.04+) it results in a deprecation warning:

```
W: --force-yes is deprecated, use one of the options starting with --allow instead.
```
(Example: https://travis-ci.com/github/heroku/stack-images/jobs/325509026#L1794)

It also appears to no longer be required, since the build completes fine in non-interactive mode without it, and no additional prompts are seen even if the build is run by hand interactively.

I've also confirmed no differences in output (other than the expected changes in log files/caches), using:
`container-diff diff --type=file <image-before> <image-after>`

See also:
https://manpages.ubuntu.com/manpages/xenial/en/man8/apt-get.8.html

Refs [W-7496420](https://gus.lightning.force.com/lightning/r/ADM_Work__c/a07B0000008Nuk5IAC/view).