### PR TITLE
Make the ca-certificates-java steps easier to follow

### DIFF
--- a/heroku-16/setup.sh
+++ b/heroku-16/setup.sh
@@ -153,11 +153,15 @@ apt-get install -y \
     wget \
     zip \
 
-# install the JDK for certificates, then remove it
+# Temporarily install ca-certificates-java to generate the certificates store used
+# by Java apps. Generation occurs in a post-install script which requires a JRE.
+# We're using OpenJDK 8 rather than something newer, to work around:
+# https://github.com/heroku/stack-images/pull/103#issuecomment-389544431
 apt-get install -y --no-install-recommends ca-certificates-java openjdk-8-jre-headless
+# Using remove rather than purge so that the generated certs are left behind.
 apt-get remove -y ca-certificates-java
-apt-get -y --purge autoremove
 apt-get purge -y openjdk-8-jre-headless
+apt-get autoremove -y --purge
 test "$(file -b /etc/ssl/certs/java/cacerts)" = "Java KeyStore"
 
 cat > /etc/ImageMagick-6/policy.xml <<'IMAGEMAGICK_POLICY'

--- a/heroku-18/setup.sh
+++ b/heroku-18/setup.sh
@@ -209,11 +209,15 @@ cat > /etc/ImageMagick-6/policy.xml <<'IMAGEMAGICK_POLICY'
 </policymap>
 IMAGEMAGICK_POLICY
 
-# install the JDK for certificates, then remove it
+# Temporarily install ca-certificates-java to generate the certificates store used
+# by Java apps. Generation occurs in a post-install script which requires a JRE.
+# We're using OpenJDK 8 rather than something newer, to work around:
+# https://github.com/heroku/stack-images/pull/103#issuecomment-389544431
 apt-get install -y --no-install-recommends ca-certificates-java openjdk-8-jre-headless
+# Using remove rather than purge so that the generated certs are left behind.
 apt-get remove -y ca-certificates-java
-apt-get -y --purge autoremove
 apt-get purge -y openjdk-8-jre-headless
+apt-get autoremove -y --purge
 test "$(file -b /etc/ssl/certs/java/cacerts)" = "Java KeyStore"
 
 rm -rf /root/*

--- a/heroku-20/setup.sh
+++ b/heroku-20/setup.sh
@@ -209,11 +209,15 @@ cat > /etc/ImageMagick-6/policy.xml <<'IMAGEMAGICK_POLICY'
 </policymap>
 IMAGEMAGICK_POLICY
 
-# install the JDK for certificates, then remove it
+# Temporarily install ca-certificates-java to generate the certificates store used
+# by Java apps. Generation occurs in a post-install script which requires a JRE.
+# We're using OpenJDK 8 rather than something newer, to work around:
+# https://github.com/heroku/stack-images/pull/103#issuecomment-389544431
 apt-get install -y --no-install-recommends ca-certificates-java openjdk-8-jre-headless
+# Using remove rather than purge so that the generated certs are left behind.
 apt-get remove -y ca-certificates-java
-apt-get -y --purge autoremove
 apt-get purge -y openjdk-8-jre-headless
+apt-get autoremove -y --purge
 test "$(file -b /etc/ssl/certs/java/cacerts)" = "Java KeyStore"
 
 rm -rf /root/*


### PR DESCRIPTION
Since it wasn't immediately obvious to me why:
* the certs weren't just extracted from `ca-certificates-java` using say `dpkg -x` to avoid the install/uninstall dance + needing JDK (reason: the certs are generated by the package at install time using a post-install script)
* autoremove was being run before the removal of the JDK (turns out the order makes no difference; the new order makes that clearer)
* an older version of the JDK was being used (without looking at git history to find https://github.com/heroku/stack-images/pull/103)

I've confirmed that moving the autoremove line later does not affect image contents (aside from the files that change every build), using:

```
docker build --no-cache heroku-18/ -t h18-before
<apply changes>
docker build --no-cache heroku-18/ -t h18-after
container-diff diff --type=apt daemon://h18-before daemon://h18-after
container-diff diff --type=file daemon://h18-before daemon://h18-after
```

Refs [W-7496420](https://gus.lightning.force.com/lightning/r/ADM_Work__c/a07B0000008Nuk5IAC/view).