### PR TITLE
Stop setting `LC_ALL=C` during image generation

### DIFF
--- a/heroku-16-build/setup.sh
+++ b/heroku-16-build/setup.sh
@@ -6,7 +6,6 @@ exec 2>&1
 set -x
 
 export DEBIAN_FRONTEND=noninteractive
-export LC_ALL=C
 
 apt-get update
 apt-get install -y \

--- a/heroku-16/setup.sh
+++ b/heroku-16/setup.sh
@@ -6,7 +6,6 @@ exec 2>&1
 set -x
 
 export DEBIAN_FRONTEND=noninteractive
-export LC_ALL=C
 
 cat > /etc/apt/sources.list <<EOF
 deb http://archive.ubuntu.com/ubuntu/ xenial main universe

--- a/heroku-18-build/setup.sh
+++ b/heroku-18-build/setup.sh
@@ -6,7 +6,6 @@ exec 2>&1
 set -x
 
 export DEBIAN_FRONTEND=noninteractive
-export LC_ALL=C
 
 apt-get update
 apt-get install -y --no-install-recommends \

--- a/heroku-18/setup.sh
+++ b/heroku-18/setup.sh
@@ -6,7 +6,6 @@ exec 2>&1
 set -x
 
 export DEBIAN_FRONTEND=noninteractive
-export LC_ALL=C
 
 cat >/etc/apt/sources.list <<EOF
 deb http://archive.ubuntu.com/ubuntu/ bionic main universe

--- a/heroku-20-build/setup.sh
+++ b/heroku-20-build/setup.sh
@@ -6,7 +6,6 @@ exec 2>&1
 set -x
 
 export DEBIAN_FRONTEND=noninteractive
-export LC_ALL=C
 
 apt-get update
 apt-get install -y --no-install-recommends \

--- a/heroku-20/setup.sh
+++ b/heroku-20/setup.sh
@@ -6,7 +6,6 @@ exec 2>&1
 set -x
 
 export DEBIAN_FRONTEND=noninteractive
-export LC_ALL=C
 
 cat >/etc/apt/sources.list <<EOF
 deb http://archive.ubuntu.com/ubuntu/ focal main universe


### PR DESCRIPTION
Since:
* The default locale reported by the `locale` command is `POSIX`, which is an alias of `C`:
  https://www.gnu.org/software/libc/manual/html_node/Standard-Locales.html
* There is no difference in the image contents with/without `LC_ALL=C` set, as confirmed by `container-diff diff --type file ...` (beyond the usual logs/fontcache/... differences).
* The env var was only set whilst `setup.sh` was being run, so has no effect on runtime usage of the stack-images.
* It was added to the stack-images repo in #15 without explanation, but seems to have been copied from here:
  https://github.com/progrium/cedarish/blob/967934e45d026fb2349422d50306ec462fc1789f/cedar14/Dockerfile#L3
  ...which itself was copied from the Ubuntu 12.10 usage here:
  https://github.com/progrium/cedarish/commit/06b175de4cd550da19db07b29d5fe30d9c491480

See also:
https://help.ubuntu.com/community/Locale

I've not modified the Cedar-14 image, since it's EOL and has noisier diffs in general when using container-diff, so not worth the effort to vet.

Refs [W-7496420](https://gus.lightning.force.com/lightning/r/ADM_Work__c/a07B0000008Nuk5IAC/view).