### PR TITLE
Add the source git reference to the image metadata API call

### DIFF
--- a/tools/bin/capture-docker-stack
+++ b/tools/bin/capture-docker-stack
@@ -12,6 +12,8 @@ STACK_VERSION=$(echo "${STACK}" | cut -d '-' -f 2-)
 DOCKER_IMAGE=heroku/$STACK_NAME:$STACK_VERSION
 DOCKER_IMAGE_VERSION=$(docker inspect "${DOCKER_IMAGE}" | jq .[].Id | cut -d ':' -f 2 | cut -b 1-12)
 
+GIT_REF=${TRAVIS_TAG:-${TRAVIS_COMMIT:?'Error: Either TRAVIS_TAG or TRAVIS_COMMIT must be set!'}}
+
 IMG_BASE=${STACK_NAME}64-$STACK_VERSION-$DOCKER_IMAGE_VERSION
 IMG=/tmp/$IMG_BASE.img
 IMG_MNT=/tmp/$IMG_BASE
@@ -46,7 +48,7 @@ if update-manifest; then
     display "Capture Package Versions"
     capture-package-versions "${DOCKER_IMAGE}" "${IMG_PKG_VERSIONS}"
     display "Uploading files"
-    upload-image "${IMG_GZ}" "${IMG_SHA256}" "${IMG_MANIFEST}" "${STACK}" "${DOCKER_IMAGE_VERSION}" "${IMG_PKG_VERSIONS}" |& indent
+    upload-image "${IMG_GZ}" "${IMG_SHA256}" "${IMG_MANIFEST}" "${STACK}" "${DOCKER_IMAGE_VERSION}" "${IMG_PKG_VERSIONS}" "${GIT_REF}" |& indent
 else
     display "Skipping image upload"
 fi

--- a/tools/bin/upload-image
+++ b/tools/bin/upload-image
@@ -8,6 +8,7 @@ IMG_MANIFEST="$3"
 STACK=$4
 VERSION="$5"
 IMG_PKG_VERSIONS="$6"
+GIT_REF="$7"
 
 display "Creating Image on ${MANIFEST_APP_URL}"
 
@@ -16,10 +17,12 @@ jq \
     --arg stack "$STACK" \
     --slurpfile packages "${IMG_PKG_VERSIONS}" \
     --arg version "$VERSION" \
+    --arg git_ref "$GIT_REF" \
     --arg sha "$(< "$IMG_SHA256")" \
     '{
         stack: $stack,
         version: $version,
+        git_ref: $git_ref,
         sha: $sha,
         packages: $packages
     }' |


### PR DESCRIPTION
So that it can be tracked/used by the app that manages image manifests, now that it supports (and requires) it be sent in the API call:
https://github.com/heroku/cheverny/pull/62

The `TRAVIS_TAG` and `TRAVIS_BRANCH` env vars are documented here:
https://docs.travis-ci.com/user/environment-variables/#default-environment-variables

Refs [W-7531996](https://gus.lightning.force.com/lightning/r/ADM_Work__c/a07B0000007obh6IAA/view).