### PR TITLE
Update Heroku-20 installed packages list

### DIFF
--- a/heroku-20-build/installed-packages.txt
+++ b/heroku-20-build/installed-packages.txt
@@ -24,7 +24,7 @@ bzip2
 bzr
 ca-certificates
 ca-certificates-java
-clang-10
+clang-9
 cmake
 cmake-data
 comerr-dev
@@ -141,9 +141,8 @@ libcap2
 libcap2-bin
 libcbor0.6
 libcc1-0
-libclang-common-10-dev
-libclang-cpp10
-libclang1-10
+libclang-common-9-dev
+libclang-cpp9
 libcom-err2
 libcroco3
 libcrypt-dev
@@ -280,7 +279,7 @@ liblcms2-dev
 libldap-2.4-2
 libldap-common
 libldap2-dev
-libllvm10
+libllvm9
 liblmdb0
 liblqr-1-0
 liblqr-1-0-dev
@@ -482,10 +481,10 @@ libzip-dev
 libzip5
 libzstd1
 linux-libc-dev
-llvm-10
-llvm-10-dev
-llvm-10-runtime
-llvm-10-tools
+llvm-9
+llvm-9-dev
+llvm-9-runtime
+llvm-9-tools
 locales
 login
 logsave
@@ -515,6 +514,7 @@ patch
 perl
 perl-base
 perl-modules-5.30
+pgdg-keyring
 pinentry-curses
 pkg-config
 poppler-data

--- a/heroku-20/installed-packages.txt
+++ b/heroku-20/installed-packages.txt
@@ -306,6 +306,7 @@ patch
 perl
 perl-base
 perl-modules-5.30
+pgdg-keyring
 pinentry-curses
 poppler-data
 postgresql-client-12


### PR DESCRIPTION
Until now the Ubuntu APT repository's PostgreSQL packages were at of the same version as those in the `apt.postgresql.org` repository, meaning that APT installed them from the Ubuntu repository instead.

However new versions of the PostgreSQL packages have recently been released to `apt.postgresql.org` repository, which means that they now take precedence:

```
$ apt-cache policy postgresql-client-common
postgresql-client-common:
  Installed: 214
  Candidate: 215.pgdg20.04+1
  Version table:
     215.pgdg20.04+1 500
        500 http://apt.postgresql.org/pub/repos/apt focal-pgdg/main amd64 Packages
 *** 214 500
        500 http://archive.ubuntu.com/ubuntu focal/main amd64 Packages
        100 /var/lib/dpkg/status
```

The `apt.postgresql.org` packages differ in two ways:
* `postgresql-client-common` has an additional dependency on `pgdg-keyring`
* `postgresql-server-dev-12` depends on Clang/LLVM 9 instead of 10

...and so have changed the resultant installed packages list, causing the Travis cron on master to fail:
https://travis-ci.com/github/heroku/stack-images/jobs/334459220

The removal of the Clang/LLVM 10 packages is a breaking change, however Heroku-20 is currently only available internally, so we do not need to work around it by explicitly installing v10 alongside v9.

The installed packages lists were regenerated using `bin/build.sh`:
https://github.com/heroku/stack-images/blob/master/BUILD.md

Longer term we should decide whether it's worth overriding the `apt.postgresql.org` repository priority so it always takes precedence over the Ubuntu APT sources - however this scenario is likely rare, and doing so would mean more version pins/package lists to keep in sync.

Refs [W-7412380](https://gus.lightning.force.com/lightning/r/ADM_Work__c/a07B0000008BZebIAG/view).