### PR TITLE
Add more comments to the build scripts

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 ## Heroku Stack Images
 
-[![Build Status](https://travis-ci.org/heroku/stack-images.svg?branch=master)](https://travis-ci.org/heroku/stack-images)
+[![Build Status](https://travis-ci.com/heroku/stack-images.svg?branch=master)](https://travis-ci.com/heroku/stack-images)
 
 This repository holds recipes for building [Heroku stack images](https://devcenter.heroku.com/articles/stack).
 The recipes are also rendered into Docker images that are available on Docker Hub:

--- a/cedar-14/setup.sh
+++ b/cedar-14/setup.sh
@@ -2,12 +2,14 @@
 
 set -euo pipefail
 
+# Redirect stderr to stdout since tracing/apt-get/dpkg spam it for things that aren't errors.
 exec 2>&1
 set -x
 
 export DEBIAN_FRONTEND=noninteractive
 export LC_ALL=C
 
+# Based on ubuntu-debootstrap:14.04's shorter sources list (compared to ubuntu:14.04)
 cat > /etc/apt/sources.list <<EOF
 deb http://archive.ubuntu.com/ubuntu/ trusty main universe
 deb http://archive.ubuntu.com/ubuntu/ trusty-security main universe

--- a/heroku-16-build/setup.sh
+++ b/heroku-16-build/setup.sh
@@ -2,6 +2,7 @@
 
 set -euo pipefail
 
+# Redirect stderr to stdout since tracing/apt-get/dpkg spam it for things that aren't errors.
 exec 2>&1
 set -x
 

--- a/heroku-16/setup.sh
+++ b/heroku-16/setup.sh
@@ -2,11 +2,16 @@
 
 set -euo pipefail
 
+# Redirect stderr to stdout since tracing/apt-get/dpkg spam it for things that aren't errors.
 exec 2>&1
 set -x
 
 export DEBIAN_FRONTEND=noninteractive
 
+# The default sources list minus backports, restricted and multiverse.
+# In order to support all features offered by Heroku Postgres, we need newer postgresql-client
+# than is available in the Ubuntu repository, so use the upstream APT repository instead:
+# https://wiki.postgresql.org/wiki/Apt
 cat > /etc/apt/sources.list <<EOF
 deb http://archive.ubuntu.com/ubuntu/ xenial main universe
 deb http://archive.ubuntu.com/ubuntu/ xenial-security main universe
@@ -15,6 +20,7 @@ deb http://archive.ubuntu.com/ubuntu/ xenial-updates main universe
 deb http://apt.postgresql.org/pub/repos/apt/ xenial-pgdg main
 EOF
 
+# From https://www.postgresql.org/media/keys/ACCC4CF8.asc
 apt-key add - <<'PGDG_ACCC4CF8'
 -----BEGIN PGP PUBLIC KEY BLOCK-----
 

--- a/heroku-18-build/setup.sh
+++ b/heroku-18-build/setup.sh
@@ -2,6 +2,7 @@
 
 set -euo pipefail
 
+# Redirect stderr to stdout since tracing/apt-get/dpkg spam it for things that aren't errors.
 exec 2>&1
 set -x
 

--- a/heroku-18/setup.sh
+++ b/heroku-18/setup.sh
@@ -2,11 +2,13 @@
 
 set -euo pipefail
 
+# Redirect stderr to stdout since tracing/apt-get/dpkg spam it for things that aren't errors.
 exec 2>&1
 set -x
 
 export DEBIAN_FRONTEND=noninteractive
 
+# The default sources list minus backports, restricted and multiverse.
 cat >/etc/apt/sources.list <<EOF
 deb http://archive.ubuntu.com/ubuntu/ bionic main universe
 deb http://archive.ubuntu.com/ubuntu/ bionic-security main universe
@@ -14,12 +16,18 @@ deb http://archive.ubuntu.com/ubuntu/ bionic-updates main universe
 EOF
 
 apt-get update
+
+# Required by apt-key and does not exist in the base image on newer Ubuntu.
 apt-get install -y --no-install-recommends gnupg
 
+# In order to support all features offered by Heroku Postgres, we need newer postgresql-client
+# than is available in the Ubuntu repository, so use the upstream APT repository instead:
+# https://wiki.postgresql.org/wiki/Apt
 cat >>/etc/apt/sources.list <<EOF
 deb http://apt.postgresql.org/pub/repos/apt/ bionic-pgdg main
 EOF
 
+# From https://www.postgresql.org/media/keys/ACCC4CF8.asc
 apt-key add - <<'PGDG_ACCC4CF8'
 -----BEGIN PGP PUBLIC KEY BLOCK-----
 

--- a/heroku-20-build/setup.sh
+++ b/heroku-20-build/setup.sh
@@ -2,6 +2,7 @@
 
 set -euo pipefail
 
+# Redirect stderr to stdout since tracing/apt-get/dpkg spam it for things that aren't errors.
 exec 2>&1
 set -x
 

--- a/heroku-20/setup.sh
+++ b/heroku-20/setup.sh
@@ -2,11 +2,13 @@
 
 set -euo pipefail
 
+# Redirect stderr to stdout since tracing/apt-get/dpkg spam it for things that aren't errors.
 exec 2>&1
 set -x
 
 export DEBIAN_FRONTEND=noninteractive
 
+# The default sources list minus backports, restricted and multiverse.
 cat >/etc/apt/sources.list <<EOF
 deb http://archive.ubuntu.com/ubuntu/ focal main universe
 deb http://archive.ubuntu.com/ubuntu/ focal-security main universe
@@ -14,12 +16,18 @@ deb http://archive.ubuntu.com/ubuntu/ focal-updates main universe
 EOF
 
 apt-get update
+
+# Required by apt-key and does not exist in the base image on newer Ubuntu.
 apt-get install -y --no-install-recommends gnupg
 
+# In order to support all features offered by Heroku Postgres, we need newer postgresql-client
+# than is available in the Ubuntu repository, so use the upstream APT repository instead:
+# https://wiki.postgresql.org/wiki/Apt
 cat >>/etc/apt/sources.list <<EOF
 deb http://apt.postgresql.org/pub/repos/apt/ focal-pgdg main
 EOF
 
+# From https://www.postgresql.org/media/keys/ACCC4CF8.asc
 apt-key add - <<'PGDG_ACCC4CF8'
 -----BEGIN PGP PUBLIC KEY BLOCK-----
 


### PR DESCRIPTION
Found these comment additions when spring-cleaning some local repos.
They are not incredibly insightful, but may still save someone else time figuring these things out again.

There's also a fix for the Travis badge URL post org->com migration.

#169