### PR TITLE
Update Heroku-20 installed packages list

### DIFF
--- a/heroku-20/installed-packages.txt
+++ b/heroku-20/installed-packages.txt
@@ -90,6 +90,7 @@ libbz2-1.0
 libc-bin
 libc-client2007e
 libc6
+libcairo-gobject2
 libcairo2
 libcap-ng0
 libcap2


### PR DESCRIPTION
The Travis cron on master is currently failing since the generated `heroku-20/installed-packages.txt` file doesn't match the checked in version:
https://travis-ci.com/github/heroku/stack-images/jobs/362055551

This is because on 2020-07-16 a new version of `librsvg2-2` was released for Focal, which added `libcairo-gobject2` to its `Depends` list:
https://ubuntuupdates.org/package/core/focal/main/updates/librsvg2-2
https://packages.ubuntu.com/focal-updates/librsvg2-2

Packages being added (vs removed) is non-breaking, so no changes are required beyond updating the installed packages list to reflect reality.

Fixes [W-7836044](https://gus.lightning.force.com/lightning/r/ADM_Work__c/a07B0000008T4z6IAC/view).