### PR TITLE
Add jq to build images

### DIFF
--- a/cedar-14/installed-packages.txt
+++ b/cedar-14/installed-packages.txt
@@ -99,6 +99,7 @@ insserv
 iproute2
 iputils-tracepath
 java-common
+jq
 klibc-utils
 kmod
 krb5-locales

--- a/cedar-14/setup.sh
+++ b/cedar-14/setup.sh
@@ -195,6 +195,7 @@ apt-get install -y --force-yes \
     gvfs \
     imagemagick \
     iputils-tracepath \
+    jq \
     language-pack-en \
     libbz2-dev \
     libc-client2007e \

--- a/heroku-16-build/installed-packages.txt
+++ b/heroku-16-build/installed-packages.txt
@@ -90,6 +90,7 @@ iputils-tracepath
 isc-dhcp-client
 isc-dhcp-common
 javascript-common
+jq
 krb5-locales
 krb5-multidev
 language-pack-en

--- a/heroku-16-build/setup.sh
+++ b/heroku-16-build/setup.sh
@@ -17,6 +17,7 @@ apt-get install -y \
     cmake \
     gettext \
     git \
+    jq \
     libacl1-dev \
     libapparmor-dev \
     libapt-pkg-dev \

--- a/heroku-18-build/installed-packages.txt
+++ b/heroku-18-build/installed-packages.txt
@@ -86,6 +86,7 @@ imagemagick-6.q16
 init-system-helpers
 iproute2
 iputils-tracepath
+jq
 krb5-multidev
 language-pack-en
 language-pack-en-base
@@ -265,6 +266,7 @@ libjpeg-turbo8
 libjpeg-turbo8-dev
 libjpeg8
 libjpeg8-dev
+libjq1
 libjson-c3
 libjsoncpp1
 libk5crypto3

--- a/heroku-18-build/setup.sh
+++ b/heroku-18-build/setup.sh
@@ -18,6 +18,7 @@ apt-get install -y --no-install-recommends \
     cmake \
     gettext \
     git \
+    jq \
     libacl1-dev \
     libapt-pkg-dev \
     libargon2-0-dev \

--- a/heroku-20-build/installed-packages.txt
+++ b/heroku-20-build/installed-packages.txt
@@ -89,6 +89,7 @@ imagemagick-6.q16
 init-system-helpers
 iproute2
 iputils-tracepath
+jq
 krb5-multidev
 language-pack-en
 language-pack-en-base
@@ -259,6 +260,7 @@ libjpeg-turbo8
 libjpeg-turbo8-dev
 libjpeg8
 libjpeg8-dev
+libjq1
 libjson-c4
 libjsoncpp1
 libk5crypto3

--- a/heroku-20-build/setup.sh
+++ b/heroku-20-build/setup.sh
@@ -18,6 +18,7 @@ apt-get install -y --no-install-recommends \
     cmake \
     gettext \
     git \
+    jq \
     libacl1-dev \
     libapt-pkg-dev \
     libargon2-dev \


### PR DESCRIPTION
Since several of the buildpacks rely upon jq and currently have to vendor or download it.

The distro jq packages are surprisingly up to date:
https://ubuntuupdates.org/package_metas?exact_match=1&q=jq
https://raw.githubusercontent.com/stedolan/jq/master/NEWS

Closes @W-7974649@.