### PR TITLE
Add libmemcached-dev to Cedar-14

### DIFF
--- a/cedar-14/installed-packages.txt
+++ b/cedar-14/installed-packages.txt
@@ -570,6 +570,8 @@ libgvc6
 libgvc6-plugins-gtk
 libgvpr2
 libharfbuzz0b
+libhashkit-dev
+libhashkit2
 libhcrypto4-heimdal
 libheimbase1-heimdal
 libheimntlm0-heimdal
@@ -635,6 +637,10 @@ libmagickcore5-extra
 libmagickwand-dev
 libmagickwand5
 libmcrypt4
+libmemcached-dev
+libmemcached10
+libmemcachedprotocol0
+libmemcachedutil2
 libmodule-pluggable-perl
 libmount1
 libmpc3
@@ -713,6 +719,7 @@ libruby1.9.1
 libsane
 libsane-common
 libsasl2-2
+libsasl2-dev
 libsasl2-modules
 libsasl2-modules-db
 libsctp1

--- a/cedar-14/setup.sh
+++ b/cedar-14/setup.sh
@@ -210,6 +210,7 @@ apt-get install -y --force-yes \
     libjpeg-dev \
     libmagickwand-dev \
     libmcrypt4 \
+    libmemcached-dev \
     libmysqlclient-dev \
     libncurses5-dev \
     libpq-dev \


### PR DESCRIPTION
Since it's already present in the Heroku-{16,18,20} build images, and by adding it to Cedar-14 it will mean `heroku-buildpack-python` can remove a manual libmemcached installation step used to support pip installing pylibmc:
https://github.com/heroku/heroku-buildpack-python/blob/ab69658efbdb3addf7b2e155ebb5bb6e518a597c/bin/steps/pylibmc

Closes @W-8006899@.