### PR TITLE
Add realpath to Cedar-14

### DIFF
--- a/cedar-14/installed-packages.txt
+++ b/cedar-14/installed-packages.txt
@@ -904,6 +904,7 @@ python3-minimal
 python3.4
 python3.4-minimal
 readline-common
+realpath
 rsync
 ruby
 ruby-dev

--- a/cedar-14/setup.sh
+++ b/cedar-14/setup.sh
@@ -234,6 +234,7 @@ apt-get install -y --force-yes \
     psmisc \
     python \
     python-dev \
+    realpath \
     ruby \
     ruby-dev \
     socat \


### PR DESCRIPTION
Since it's already present in the Heroku-{16,18,20} build images, and adding it to Cedar-14 removes another inconsistency buildpacks have to work around. (Such as the PHP buildpack, and see also: https://github.com/heroku/heroku-buildpack-python/pull/992#issuecomment-670593085)

https://ubuntuupdates.org/package/core/trusty/main/base/realpath

Closes @W-8006892@.