### PR TITLE
Revert "Add libmemcached-dev to Cedar-14"

### DIFF
--- a/cedar-14/installed-packages.txt
+++ b/cedar-14/installed-packages.txt
@@ -570,8 +570,6 @@ libgvc6
 libgvc6-plugins-gtk
 libgvpr2
 libharfbuzz0b
-libhashkit-dev
-libhashkit2
 libhcrypto4-heimdal
 libheimbase1-heimdal
 libheimntlm0-heimdal
@@ -637,10 +635,6 @@ libmagickcore5-extra
 libmagickwand-dev
 libmagickwand5
 libmcrypt4
-libmemcached-dev
-libmemcached10
-libmemcachedprotocol0
-libmemcachedutil2
 libmodule-pluggable-perl
 libmount1
 libmpc3
@@ -719,7 +713,6 @@ libruby1.9.1
 libsane
 libsane-common
 libsasl2-2
-libsasl2-dev
 libsasl2-modules
 libsasl2-modules-db
 libsctp1

--- a/cedar-14/setup.sh
+++ b/cedar-14/setup.sh
@@ -210,7 +210,6 @@ apt-get install -y --force-yes \
     libjpeg-dev \
     libmagickwand-dev \
     libmcrypt4 \
-    libmemcached-dev \
     libmysqlclient-dev \
     libncurses5-dev \
     libpq-dev \


### PR DESCRIPTION
Reverts #175 since it turns out that even though the `libmemcached-dev` package has a `depends` on `libsasl2-dev`, the `libmemcached10` package isn't actually built with sasl2 support enabled (unlike for newer Ubuntu). As such for several use-cases (such as the Python and PHP buildpack's usages of it), we won't be able to use the stack image version and would need to continue to vendor anyway.

Since a new stack image release hasn't been published to the platform since #175 landed (only staging), it's safe to remove the package to avoid leaving an unused package in the image (which may also cause issues if there are any buildpacks out there that proritise the system package over their vendored one).

Refs W-8006899.