### PR TITLE
Add libc6-dev into the stack image

### DIFF
--- a/BUILD.md
+++ b/BUILD.md
@@ -1,5 +1,24 @@
 # Building Stack Images Locally
 
+## Prepare your local environment
+
+The build scripts in this repository require bash 4+. To update to newer bash on OS X, see:
+https://johndjameson.com/blog/updating-your-shell-with-homebrew/
+
+## Adding packages to the stack image
+
+Add the package you want to the approproate `setup.sh` for example `heroku-18/setup.sh`:
+
+```diff
++    libc6-dev \
+```
+
+Once done, run the `bin/build.sh` locally to generate the corresponding `installed-packages.txt`.
+
+The `*-build` variants include all the packages from the non-build variant by default. This means that if you're adding a package to both, you only need to add them to the non-build variant. The example above will add `libc6-dev` to both `heroku-18` and `heroku-18-build`.
+
+## Build
+
 To build the stack images locally, run this from the repo root:
 
     bin/build.sh STACK DOCKER_TAG DOCKER_BUILD_TAG

--- a/heroku-18/installed-packages.txt
+++ b/heroku-18/installed-packages.txt
@@ -87,7 +87,9 @@ libbsd0
 libbz2-1.0
 libc-bin
 libc-client2007e
+libc-dev-bin
 libc6
+libc6-dev
 libcairo2
 libcap-ng0
 libcap2
@@ -279,6 +281,7 @@ libxslt1.1
 libyaml-0-2
 libzip4
 libzstd1
+linux-libc-dev
 locales
 login
 lsb-base

--- a/heroku-18/setup.sh
+++ b/heroku-18/setup.sh
@@ -133,6 +133,7 @@ apt-get install -y --no-install-recommends \
     less \
     libargon2-0 \
     libc-client2007e \
+    libc6-dev \
     libcairo2 \
     libcroco3 \
     libcurl4 \

--- a/heroku-20/installed-packages.txt
+++ b/heroku-20/installed-packages.txt
@@ -89,7 +89,9 @@ libbsd0
 libbz2-1.0
 libc-bin
 libc-client2007e
+libc-dev-bin
 libc6
+libc6-dev
 libcairo-gobject2
 libcairo2
 libcap-ng0
@@ -99,6 +101,7 @@ libcbor0.6
 libcc1-0
 libcom-err2
 libcroco3
+libcrypt-dev
 libcrypt1
 libctf-nobfd0
 libctf0
@@ -282,6 +285,7 @@ libxtables12
 libyaml-0-2
 libzip5
 libzstd1
+linux-libc-dev
 locales
 login
 logsave

--- a/heroku-20/setup.sh
+++ b/heroku-20/setup.sh
@@ -133,6 +133,7 @@ apt-get install -y --no-install-recommends \
     less \
     libargon2-1 \
     libc-client2007e \
+    libc6-dev \
     libcairo2 \
     libcroco3 \
     libcurl4 \


### PR DESCRIPTION
Currently on heroku-18 and heroku-20 you cannot compile at runtime, but can on heroku-16. This prevents `mjit` which relies on out of band compilation to implement jit. Here are some details about how I uncovered this:

On a heroku run bash instance this code fails on heroku-18 but works on heroku-16:

```
~ $ cat > numprocessors.c <<EOL
>   #include <unistd.h>
>   #include <stdio.h>
>
>   int main() {
>     int val = sysconf(_SC_NPROCESSORS_ONLN);
>     printf("# => Number of processors from sysconf: %i\n", val);
>     return 0;
>   }
> EOL
~ $ gcc numprocessors.c && ./a.out
numprocessors.c:1:12: fatal error: unistd.h: No such file or directory
   #include <unistd.h>
            ^~~~~~~~~~
```

here's a blog post from when it worked https://schneems.com/2017/08/01/is-webrick-webscale/

Also Ruby's "mjit" does not work on Heroku-18:

```
~ $ ruby --jit-wait --jit-verbose=5 -e "puts 'yoyoyoyo'"
MJIT: CC defaults to /usr/bin/gcc
MJIT: tmp_dir is /tmp
Locking in mjit_cont_new
Locked in mjit_cont_new
Click to expand inline (14 lines)
```


It deadlocks since it's never able to compile anything using mjit, it prints those unlock/lock lines out forever.