### PR TITLE
Add `vi` to the stack image

### DIFF
--- a/heroku-16-build/installed-packages.txt
+++ b/heroku-16-build/installed-packages.txt
@@ -618,6 +618,8 @@ ubuntu-keyring
 ucf
 unzip
 util-linux
+vim-common
+vim-tiny
 wget
 x11-common
 x11proto-core-dev

--- a/heroku-16/installed-packages.txt
+++ b/heroku-16/installed-packages.txt
@@ -362,6 +362,8 @@ ubuntu-keyring
 ucf
 unzip
 util-linux
+vim-common
+vim-tiny
 wget
 xauth
 xdg-user-dirs

--- a/heroku-16/setup.sh
+++ b/heroku-16/setup.sh
@@ -155,6 +155,7 @@ apt-get install -y \
     tar \
     telnet \
     tzdata \
+    vim-tiny \
     wget \
     zip \
 

--- a/heroku-18-build/installed-packages.txt
+++ b/heroku-18-build/installed-packages.txt
@@ -563,6 +563,8 @@ ubuntu-keyring
 ucf
 unzip
 util-linux
+vim-common
+vim-tiny
 wget
 x11-common
 x11proto-core-dev
@@ -570,6 +572,7 @@ x11proto-dev
 x11proto-xext-dev
 xorg-sgml-doctools
 xtrans-dev
+xxd
 xz-utils
 zip
 zlib1g

--- a/heroku-18/installed-packages.txt
+++ b/heroku-18/installed-packages.txt
@@ -347,7 +347,10 @@ ubuntu-keyring
 ucf
 unzip
 util-linux
+vim-common
+vim-tiny
 wget
+xxd
 xz-utils
 zip
 zlib1g

--- a/heroku-18/setup.sh
+++ b/heroku-18/setup.sh
@@ -196,6 +196,7 @@ apt-get install -y --no-install-recommends \
     telnet \
     tzdata \
     unzip \
+    vim-tiny \
     wget \
     xz-utils \
     zip \

--- a/heroku-20-build/installed-packages.txt
+++ b/heroku-20-build/installed-packages.txt
@@ -576,6 +576,8 @@ ucf
 unzip
 util-linux
 uuid-dev
+vim-common
+vim-tiny
 wget
 x11-common
 x11proto-core-dev
@@ -583,6 +585,7 @@ x11proto-dev
 x11proto-xext-dev
 xorg-sgml-doctools
 xtrans-dev
+xxd
 xz-utils
 zip
 zlib1g

--- a/heroku-20/installed-packages.txt
+++ b/heroku-20/installed-packages.txt
@@ -347,7 +347,10 @@ ubuntu-keyring
 ucf
 unzip
 util-linux
+vim-common
+vim-tiny
 wget
+xxd
 xz-utils
 zip
 zlib1g

--- a/heroku-20/setup.sh
+++ b/heroku-20/setup.sh
@@ -196,6 +196,7 @@ apt-get install -y --no-install-recommends \
     telnet \
     tzdata \
     unzip \
+    vim-tiny \
     wget \
     xz-utils \
     zip \


### PR DESCRIPTION
When debugging customer issues in production it can be necessary to modify files with debugging statements. Currently there are no editors on runtime images. This PR adds the basic `vi` to the runtime image. 

```
docker run -it --rm heroku/heroku:18 bash
root@c835b7f1d03d:/# vi --version | head -n 1
VIM - Vi IMproved 8.0 (2016 Sep 12, compiled Mar 18 2020 18:29:15)
```

This appears to add 2mb to the stack image:

```
       heroku/heroku:18                                     487MB # main
       heroku/heroku:18                                     489MB # tiny-vim
```

## Add a package checklist

- How likely is this to break existing builds?
  - Very unlikely
- How much of an impact will it have on stack image size?
  - 2mb
-  Is is covered by standard security update policy?
   - It is in the Main respository: https://ubuntuupdates.org/package_metas?q=vim-tiny
- How often does it have a security issue?
  - Not that often https://ubuntuupdates.org/package/core/xenial/main/security/vim-tiny
-  Is it for build only (in which case a bit more flexible) or runtime too?
   - vi is for runtime only 
- Does it encourage any anti-patterns (eg libsqlite3-dev)
  - Being able to edit files in prod might give people the mistaken impression that this is like the bad old days of ssh where you could pop into a server and do a "hot fix" but modifications will be restricted to only the bash dyno. This is not that bad.