### PR TITLE
python-is-python3

### DIFF
--- a/heroku-20-build/installed-packages.txt
+++ b/heroku-20-build/installed-packages.txt
@@ -525,6 +525,7 @@ postgresql-client-common
 postgresql-common
 postgresql-server-dev-12
 procps
+python-is-python3
 python2
 python2-minimal
 python2.7

--- a/heroku-20/installed-packages.txt
+++ b/heroku-20/installed-packages.txt
@@ -317,6 +317,7 @@ poppler-data
 postgresql-client-12
 postgresql-client-common
 procps
+python-is-python3
 python3
 python3-minimal
 python3.8

--- a/heroku-20/setup.sh
+++ b/heroku-20/setup.sh
@@ -184,8 +184,8 @@ apt-get install -y --no-install-recommends \
     openssh-server \
     patch \
     postgresql-client-12 \
-    python3 \
     python-is-python3 \
+    python3 \
     rename \
     rsync \
     ruby \

--- a/heroku-20/setup.sh
+++ b/heroku-20/setup.sh
@@ -185,6 +185,7 @@ apt-get install -y --no-install-recommends \
     patch \
     postgresql-client-12 \
     python3 \
+    python-is-python3 \
     rename \
     rsync \
     ruby \


### PR DESCRIPTION
This restores 'python' as an available binary, aliased to 'python3'.

We deem this the better alternative to not having it, because programs might invoke 'python', and a 'command not found' error would presumably much more confusing than a Python 3 related error (and those should be getting pretty rare now anyway). Same for anything that has a '/usr/bin/env python' or similar shebang.

Previous stacks have 'python' aliased to 'python2', but given how that's (finally) EOL, we'd only be kicking painful migrations down the road, and people upgrading stacks are already touching their code base anyway, so better to rip the bandaid off in one go.

GUS-W-8140606
