### PR TITLE
add libwebp-dev runtime deps

### DIFF
--- a/heroku-18-build/installed-packages.txt
+++ b/heroku-18-build/installed-packages.txt
@@ -442,6 +442,8 @@ libuv1-dev
 libvpx-dev
 libvpx5
 libwebp6
+libwebpdemux2
+libwebpmux3
 libwind0-heimdal
 libwmf-dev
 libwmf0.2-7

--- a/heroku-18/installed-packages.txt
+++ b/heroku-18/installed-packages.txt
@@ -263,6 +263,8 @@ libunistring2
 libuuid1
 libuv1
 libwebp6
+libwebpdemux2
+libwebpmux3
 libwind0-heimdal
 libwmf0.2-7
 libwrap0

--- a/heroku-18/setup.sh
+++ b/heroku-18/setup.sh
@@ -171,6 +171,9 @@ apt-get install -y --no-install-recommends \
     libthai-data \
     libthai0 \
     libuv1 \
+    libwebp6 \
+    libwebpdemux2 \
+    libwebpmux3 \
     libxcb-render0 \
     libxcb-shm0 \
     libxrender1 \

--- a/heroku-20-build/installed-packages.txt
+++ b/heroku-20-build/installed-packages.txt
@@ -95,7 +95,6 @@ language-pack-en
 language-pack-en-base
 less
 lib32gcc-s1
-lib32gcc1
 lib32stdc++6
 libacl1
 libacl1-dev
@@ -443,6 +442,7 @@ libuv1-dev
 libvpx-dev
 libvpx6
 libwebp6
+libwebpdemux2
 libwebpmux3
 libwind0-heimdal
 libwmf-dev

--- a/heroku-20/installed-packages.txt
+++ b/heroku-20/installed-packages.txt
@@ -265,6 +265,7 @@ libunistring2
 libuuid1
 libuv1
 libwebp6
+libwebpdemux2
 libwebpmux3
 libwind0-heimdal
 libwmf0.2-7

--- a/heroku-20/setup.sh
+++ b/heroku-20/setup.sh
@@ -171,6 +171,9 @@ apt-get install -y --no-install-recommends \
     libthai-data \
     libthai0 \
     libuv1 \
+    libwebp6 \
+    libwebpdemux2 \
+    libwebpmux3 \
     libxcb-render0 \
     libxcb-shm0 \
     libxrender1 \


### PR DESCRIPTION
We already have libwebp6 on heroku-18 and heroku-20, and libwebpdemux3 on heroku-20, as these are dependencies of other packages.

When installing libwebp-dev during a build, this will pull down libwebpdemux3 (and also libwebpmux3 on heroku-18), as these are dependencies. A program being built may now link against these additional libraries, but they're not in the runtime image.

Explicitly adding all three libraries so the setup list makes more sense to the casual observer.

GUS-W-8202718