### PR TITLE
Fix area limit unit (using pixels)

### DIFF
--- a/heroku-18/setup.sh
+++ b/heroku-18/setup.sh
@@ -210,7 +210,7 @@ cat > /etc/ImageMagick-6/policy.xml <<'IMAGEMAGICK_POLICY'
   <policy domain="resource" name="map" value="512MiB"/>
   <policy domain="resource" name="width" value="16KP"/>
   <policy domain="resource" name="height" value="16KP"/>
-  <policy domain="resource" name="area" value="128MB"/>
+  <policy domain="resource" name="area" value="128MP"/>
   <policy domain="resource" name="disk" value="1GiB"/>
   <policy domain="delegate" rights="none" pattern="URL" />
   <policy domain="delegate" rights="none" pattern="HTTPS" />

--- a/heroku-20/setup.sh
+++ b/heroku-20/setup.sh
@@ -211,7 +211,7 @@ cat > /etc/ImageMagick-6/policy.xml <<'IMAGEMAGICK_POLICY'
   <policy domain="resource" name="map" value="512MiB"/>
   <policy domain="resource" name="width" value="16KP"/>
   <policy domain="resource" name="height" value="16KP"/>
-  <policy domain="resource" name="area" value="128MB"/>
+  <policy domain="resource" name="area" value="128MP"/>
   <policy domain="resource" name="disk" value="1GiB"/>
   <policy domain="delegate" rights="none" pattern="URL" />
   <policy domain="delegate" rights="none" pattern="HTTPS" />


### PR DESCRIPTION
It's hard to find out, what units we should use for area resource limits.

Official ImageMagick documentation contradicts itself:
* [ImageMagick _PixelCache_ architecture](https://imagemagick.org/script/architecture.php#:~:text=maximum%20area%20in%20bytes%20of%20any%20one%20image%20that%20can%20reside%20in%20the%20pixel%20cache%20memory.%20If%20this%20limit%20is%20exceeded,%20the%20image%20is%20automagically%20cached%20to%20disk%20and%20optionally%20memory-mapped.)
* [ImageMagick resource limits (environment variables)](https://imagemagick.org/script/resources.php#:~:text=Set%20the%20maximum%20width%20*%20height%20of%20an%20image%20that%20can%20reside%20in%20the%20pixel%20cache%20memory.%20Images%20that%20exceed%20the%20area%20limit%20are%20cached%20to%20disk%20(see%20MAGICK_DISK_LIMIT)%20and%20optionally%20memory-mapped.)
* [`policy.xml` example in source code](https://github.com/ImageMagick/ImageMagick/blob/8ae4ace285a385c5f58b1029f7a4a79925a42853/config/policy.xml#L65)

I'm pretty sure that the format should be pixels because that's what you get when running `identify -list resource`. It will return `Area: 128000000P` even if you configured `128MB`.