### PR TITLE
Enable Circle CI jobs on tags

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -53,10 +53,17 @@ jobs:
 workflows:
   build:
     jobs:
-      - shellcheck
+      - shellcheck:
+          filters:
+            # Enable for release tags (by default all tags are ignored).
+            tags:
+              only: /^v.*/
       - build-heroku:
           requires:
             - shellcheck
+          filters:
+            tags:
+              only: /^v.*/
           matrix:
             parameters:
               stack-version: ["16", "18", "20"]


### PR DESCRIPTION
By default Circle CI only triggers jobs on branches and not Git tags:
https://circleci.com/docs/2.0/workflows/#executing-workflows-for-a-git-tag

As such, we must explicitly enable jobs for tags of form `v*`, since we git tag as part of stack-image release process.

Closes GUS-W-9189760.