### PR TITLE
Don't run Docker interactively when extracting package versions

### DIFF
--- a/tools/bin/capture-package-versions
+++ b/tools/bin/capture-package-versions
@@ -5,4 +5,4 @@ set -euo pipefail
 DOCKER_IMAGE=$1
 OUTPUT_FILE=$2
 
-docker run --rm -ti "${DOCKER_IMAGE}" dpkg-query -W -f "\${package},\${version}\n" | jq -s -R -f /usr/local/bin/csv-to-array.jq > "${OUTPUT_FILE}"
+docker run --rm "${DOCKER_IMAGE}" dpkg-query -W -f "\${package},\${version}\n" | jq -s -R -f /usr/local/bin/csv-to-array.jq > "${OUTPUT_FILE}"

--- a/tools/bin/csv-to-array.jq
+++ b/tools/bin/csv-to-array.jq
@@ -1,5 +1,5 @@
   [
-    split("\r\n")[]                  # transform csv input into array
+    split("\n")[]                  # transform csv input into array
   | split(",")                    # where first element has key names
   | select(length==2)              # and other elements have values
   ]


### PR DESCRIPTION
In the most recent stack image release (the first after migrating to Circle CI), the generated package changelogs contained stray `^@^@` characters (2x `NUL` control characters) at the start of the `adduser` package name:

```
 <tbody>
   <tr id="^@^@adduser">
     <td style="white-space: nowrap"><code>^@^@adduser</code></td>
     <td>3.113+nmu3ubuntu4</td>
     <td>3.116ubuntu1</td>
     <td>3.118ubuntu2</td>
   </tr>
...
```

The package names/versions are generated by `capture-package-versions`, and since `adduser` is the first package in the list, this implies that stray control characters are being injected immediately prior to the `dpkg-query` output.

This is likely due to this Circle CI bug (which we previously reported after running into it during Hatchet tests):
https://github.com/CircleCI-Public/circleci-cli/issues/456

To work around this bug, the `docker run` command is no longer run interactively, which prevents the stray control characters on STDIN from being included in the output. This use of interactive was unnecessary, so this is arguably a more correct implementation regardless of the bug.

Of note, removing `-t` means that the `docker run` output now uses `\n` as newline separators instead of `\r\n`, so `csv-to-array.jq` has been updated accordingly. This is safe to do since that jq script is not used by anything else.

Closes GUS-W-9190205.