### PR TITLE
Add libzstd1 to Heroku-16's expected packages list

### DIFF
--- a/heroku-16-build/installed-packages.txt
+++ b/heroku-16-build/installed-packages.txt
@@ -501,6 +501,7 @@ libyaml-0-2
 libyaml-dev
 libzip-dev
 libzip4
+libzstd1
 linux-libc-dev
 llvm-6.0
 llvm-6.0-dev

--- a/heroku-16/installed-packages.txt
+++ b/heroku-16/installed-packages.txt
@@ -280,6 +280,7 @@ libxslt1.1
 libxtables11
 libyaml-0-2
 libzip4
+libzstd1
 linux-libc-dev
 locales
 login


### PR DESCRIPTION
CI for Heroku-16 has just started failing on `main` due to an upstream package dependency change. The `apt`-related packages now depend upon `libzstd1`, so it gets installed transitively even though we don't explicitly install it ourselves.

Therefore the expected packages list (which is used for verification in CI), must be updated for CI to pass.

See:
https://ubuntuupdates.org/package/core/xenial/main/updates/apt

Closes GUS-W-9263497.