### PR TITLE
Upgrade Circle CI machine and docker images

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -2,7 +2,7 @@ version: 2.1
 jobs:
   shellcheck:
     docker:
-      - image: koalaman/shellcheck-alpine:v0.7.1
+      - image: koalaman/shellcheck-alpine:v0.7.2
     steps:
       - checkout
       - run:
@@ -15,7 +15,7 @@ jobs:
         type: enum
         enum: ["16", "18", "20"]
     machine:
-      image: ubuntu-2004:202101-01
+      image: ubuntu-2004:202104-01
     environment:
       IMAGE_TAG: heroku/heroku:<< parameters.stack-version >>
       PRIVATE_IMAGE_TAG: heroku/heroku-private:<< parameters.stack-version >>


### PR DESCRIPTION
This is primarily to pick up security fixes in the machine image (given it's part of the release pipeline), but I've updated the shellcheck image too whilst I was here.

* `ubuntu-2004:202101-01` -> `ubuntu-2004:202104-01`
* `koalaman/shellcheck-alpine:v0.7.1` -> `koalaman/shellcheck-alpine:v0.7.2`

See:
https://circleci.com/docs/2.0/configuration-reference/#available-machine-images
https://github.com/koalaman/shellcheck/blob/master/CHANGELOG.md#v072---2021-04-19

Closes GUS-W-9263614.