### PR TITLE
Add libjson-perl to the expected packages list

### DIFF
--- a/heroku-18-build/installed-packages.txt
+++ b/heroku-18-build/installed-packages.txt
@@ -268,6 +268,7 @@ libjpeg8
 libjpeg8-dev
 libjq1
 libjson-c3
+libjson-perl
 libjsoncpp1
 libk5crypto3
 libkadm5clnt-mit11

--- a/heroku-20-build/installed-packages.txt
+++ b/heroku-20-build/installed-packages.txt
@@ -261,6 +261,7 @@ libjpeg8
 libjpeg8-dev
 libjq1
 libjson-c4
+libjson-perl
 libjsoncpp1
 libk5crypto3
 libkadm5clnt-mit11


### PR DESCRIPTION
CI for Heroku-18 and Heroku-20 have just started failing on `main` due to an upstream package dependency change. Today's v13.3 release of the `postgres-common` package now depends upon `libjson-perl`, so it gets installed transitively even though we don't explicitly install it ourselves.

Therefore the expected packages list (which is used for verification in CI), must be updated for CI to pass.

Example failing CI run:
https://app.circleci.com/pipelines/github/heroku/stack-images/35/workflows/cf18a87a-7897-483e-8ba8-239a6598c746/jobs/120

```
Generated files differ from checked-in versions! Run bin/build.sh to regenerate them locally.

Changed files:
 M heroku-20-build/installed-packages.txt

diff --git a/heroku-20-build/installed-packages.txt b/heroku-20-build/installed-packages.txt
index 21be6fe..89581e9 100644
--- a/heroku-20-build/installed-packages.txt
+++ b/heroku-20-build/installed-packages.txt
@@ -261,6 +261,7 @@ libjpeg8
 libjpeg8-dev
 libjq1
 libjson-c4
+libjson-perl
 libjsoncpp1
 libk5crypto3
 libkadm5clnt-mit11
```

The reason why `libjson-perl` is installed:

```
$ docker run --rm -it heroku/heroku:20-build bash -c 'apt-get update -qq && apt-cache rdepends --installed libjson-perl'
libjson-perl
Reverse Depends:
  postgresql-common
  postgresql-common
  postgresql-common
  postgresql-common
```

Closes GUS-W-9269128.