### PR TITLE
Add CNB Stack Images

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -13,7 +13,7 @@ jobs:
     parameters:
       stack-version:
         type: enum
-        enum: ["18", "20", "22"]
+        enum: ["18", "20", "22", "22-cnb"]
     machine:
       image: ubuntu-2204:2022.04.1
     environment:
@@ -66,4 +66,4 @@ workflows:
               only: /^v.*/
           matrix:
             parameters:
-              stack-version: ["18", "20", "22"]
+              stack-version: ["18", "20", "22", "22-cnb"]

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -59,7 +59,7 @@ workflows:
             tags:
               only: /^v.*/
       - build-stack:
-          name: build-heroku-stack-images
+          name: build-heroku-stack-image-<< matrix.stack-version >>
           requires:
             - shellcheck
           filters:
@@ -69,9 +69,9 @@ workflows:
             parameters:
               stack-version: ["18", "20", "22"]
       - build-stack:
-          name: build-cnb-stack-images
+          name: build-cnb-stack-image-<< matrix.stack-version >>
           requires:
-            - build-heroku-stack-images
+            - build-heroku-stack-image-22
           filters:
             tags:
               only: /^v.*/

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -71,9 +71,9 @@ workflows:
       - build-stack:
           name: build-stack-heroku-<< matrix.stack-version >>
           requires:
-            - build-heroku-stack-image-18
-            - build-heroku-stack-image-20
-            - build-heroku-stack-image-22
+            - build-stack-heroku-18
+            - build-stack-heroku-20
+            - build-stack-heroku-22
           filters:
             tags:
               only: /^v.*/

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -32,6 +32,7 @@ jobs:
             if [[ -n "$status" ]]; then
               echo "Generated files differ from checked-in versions! Run bin/build.sh to regenerate them locally."
               echo -e "\nChanged files:\n${status}\n"
+              git diff
               exit 1
             fi
       - when:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -13,7 +13,7 @@ jobs:
     parameters:
       stack-version:
         type: enum
-        enum: ["18", "20", "22", "22-cnb"]
+        enum: ["18", "20", "22", "18-cnb", "20-cnb", "22-cnb"]
     machine:
       image: ubuntu-2204:2022.04.1
     environment:
@@ -59,7 +59,7 @@ workflows:
             tags:
               only: /^v.*/
       - build-stack:
-          name: build-heroku-stack-image-<< matrix.stack-version >>
+          name: build-stack-heroku-<< matrix.stack-version >>
           requires:
             - shellcheck
           filters:
@@ -69,12 +69,14 @@ workflows:
             parameters:
               stack-version: ["18", "20", "22"]
       - build-stack:
-          name: build-cnb-stack-image-<< matrix.stack-version >>
+          name: build-stack-heroku-<< matrix.stack-version >>
           requires:
+            - build-heroku-stack-image-18
+            - build-heroku-stack-image-20
             - build-heroku-stack-image-22
           filters:
             tags:
               only: /^v.*/
           matrix:
             parameters:
-              stack-version: ["22-cnb"]
+              stack-version: ["18-cnb", "20-cnb", "22-cnb"]

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -32,7 +32,7 @@ jobs:
             if [[ -n "$status" ]]; then
               echo "Generated files differ from checked-in versions! Run bin/build.sh to regenerate them locally."
               echo -e "\nChanged files:\n${status}\n"
-              git diff --exit-code
+              exit 1
             fi
       - when:
           condition:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -9,7 +9,7 @@ jobs:
           name: Run shellcheck
           command: find . -type f \( -name "*.sh" -o -path "*/bin/*" \) ! -name '*.jq' | xargs -t shellcheck
 
-  build-heroku:
+  build-stack:
     parameters:
       stack-version:
         type: enum
@@ -58,7 +58,8 @@ workflows:
             # Enable for release tags (by default all tags are ignored).
             tags:
               only: /^v.*/
-      - build-heroku:
+      - build-stack:
+          name: build-heroku-stack-images
           requires:
             - shellcheck
           filters:
@@ -66,4 +67,14 @@ workflows:
               only: /^v.*/
           matrix:
             parameters:
-              stack-version: ["18", "20", "22", "22-cnb"]
+              stack-version: ["18", "20", "22"]
+      - build-stack:
+          name: build-cnb-stack-images
+          requires:
+            - build-heroku-stack-images
+          filters:
+            tags:
+              only: /^v.*/
+          matrix:
+            parameters:
+              stack-version: ["22-cnb"]

--- a/BUILD.md
+++ b/BUILD.md
@@ -32,7 +32,9 @@ For example:
 The supported stacks are:
 
 * `heroku-18` (will also build a `heroku-18-build` image)
+* `heroku-18-cnb` (will also build a `heroku-18-cnb-build` image)
 * `heroku-20` (will also build a `heroku-20-build` image)
+* `heroku-20-cnb` (will also build a `heroku-20-cnb-build` image)
 * `heroku-22` (will also build a `heroku-22-build` image)
 * `heroku-22-cnb` (will also build a `heroku-22-cnb-build` image)
 

--- a/BUILD.md
+++ b/BUILD.md
@@ -17,6 +17,8 @@ Once done, run the `bin/build.sh` locally to generate the corresponding `install
 
 The `*-build` variants include all the packages from the non-build variant by default. This means that if you're adding a package to both, you only need to add them to the non-build variant. The example above will add `libc6-dev` to both `heroku-18` and `heroku-18-build`.
 
+The `*cnb*` variants inherit the installed packages from the non-`*cnb*` variant. Add packages to a non-`*cnb*` variant to add them to the `*cnb*` variant.
+
 ## Build
 
 To build the stack images locally, run this from the repo root:
@@ -32,6 +34,7 @@ The supported stacks are:
 * `heroku-18` (will also build a `heroku-18-build` image)
 * `heroku-20` (will also build a `heroku-20-build` image)
 * `heroku-22` (will also build a `heroku-22-build` image)
+* `heroku-22-cnb` (will also build a `heroku-22-cnb-build` image)
 
 
 # Releasing Stack Images
@@ -41,9 +44,11 @@ When building Stack Images for release, we use the Circle CI build system.
 * Any push to `main` will build the images and push the `nightly` tag.
 * Any new tag will build the image and push the `latest` tag, as well as one with the name of the GIT tag.
 
-# Releasing Stack Images Locally (Prime)
+# Releasing Heroku Stack Images Locally (Prime)
 
-When building Stack Images for release locally, you'll need a number of additional steps.
+When building Heroku Stack Images for release locally, youll need a number of additional steps.
+
+NOTE: These steps do *not* apply to `*cnb*` images.
 
     # Build the stack image(s) as you would above
     cd stack-images/tools

--- a/README.md
+++ b/README.md
@@ -9,8 +9,12 @@ The recipes are also rendered into Docker images that are available on Docker Hu
 |-------------------------------------------|---------------------------------------|----------------------------|----------------|
 | [heroku/heroku:18][heroku-tags]           | [ubuntu:18.04][ubuntu-tags]           | Heroku Runtime Stack Image | Available      |
 | [heroku/heroku:18-build][heroku-tags]     | [heroku/heroku:18][heroku-tags]       | Heroku Build Stack Image   | Available      |
+| [heroku/heroku:18-cnb][heroku-tags]       | [heroku/heroku:18][heroku-tags]       | CNB Runtime Stack Image    | Available      |
+| [heroku/heroku:18-cnb-build][heroku-tags] | [heroku/heroku:18-build][heroku-tags] | CNB Build Stack Image      | Available      |
 | [heroku/heroku:20][heroku-tags]           | [ubuntu:20.04][ubuntu-tags]           | Heroku Runtime Stack Image | Suggested      |
 | [heroku/heroku:20-build][heroku-tags]     | [heroku/heroku:20][heroku-tags]       | Heroku Build Stack Image   | Suggested      |
+| [heroku/heroku:20-cnb][heroku-tags]       | [heroku/heroku:20][heroku-tags]       | CNB Runtime Stack Image    | Suggested      |
+| [heroku/heroku:20-cnb-build][heroku-tags] | [heroku/heroku:20-build][heroku-tags] | CNB Build Stack Image      | Suggested      |
 | [heroku/heroku:22][heroku-tags]           | [ubuntu:22.04][ubuntu-tags]           | Heroku Runtime Stack Image | In Development |
 | [heroku/heroku:22-build][heroku-tags]     | [heroku/heroku:22][heroku-tags]       | Heroku Build Stack Image   | In Development |
 | [heroku/heroku:22-cnb][heroku-tags]       | [heroku/heroku:22][heroku-tags]       | CNB Runtime Stack Image    | In Development |

--- a/README.md
+++ b/README.md
@@ -5,7 +5,16 @@
 This repository holds recipes for building [Heroku stack images](https://devcenter.heroku.com/articles/stack).
 The recipes are also rendered into Docker images that are available on Docker Hub:
 
-* [Heroku-{18,20} Docker images](https://registry.hub.docker.com/r/heroku/heroku/)
+| Image                                     | Base                                  | Type                       | Status         |
+|-------------------------------------------|---------------------------------------|----------------------------|----------------|
+| [heroku/heroku:18][heroku-tags]           | [ubuntu:18.04][ubuntu-tags]           | Heroku Runtime Stack Image | Available      |
+| [heroku/heroku:18-build][heroku-tags]     | [heroku/heroku:18][heroku-tags]       | Heroku Build Stack Image   | Available      |
+| [heroku/heroku:20][heroku-tags]           | [ubuntu:20.04][ubuntu-tags]           | Heroku Runtime Stack Image | Suggested      |
+| [heroku/heroku:20-build][heroku-tags]     | [heroku/heroku:20][heroku-tags]       | Heroku Build Stack Image   | Suggested      |
+| [heroku/heroku:22][heroku-tags]           | [ubuntu:22.04][ubuntu-tags]           | Heroku Runtime Stack Image | In Development |
+| [heroku/heroku:22-build][heroku-tags]     | [heroku/heroku:22][heroku-tags]       | Heroku Build Stack Image   | In Development |
+| [heroku/heroku:22-cnb][heroku-tags]       | [heroku/heroku:22][heroku-tags]       | CNB Runtime Stack Image    | In Development |
+| [heroku/heroku:22-cnb-build][heroku-tags] | [heroku/heroku:22-build][heroku-tags] | CNB Build Stack Image      | In Development |
 
 ### Learn more
 
@@ -13,3 +22,6 @@ The recipes are also rendered into Docker images that are available on Docker Hu
 * [Stack update policy](https://devcenter.heroku.com/articles/stack-update-policy)
 
 See [BUILD.md](BUILD.md) for instructions on how to build the images yourself.
+
+[heroku-tags]: https://hub.docker.com/r/heroku/heroku/tags
+[ubuntu-tags]: https://hub.docker.com/_/ubuntu?tab=tags

--- a/bin/build.sh
+++ b/bin/build.sh
@@ -19,7 +19,7 @@ echo "${DOCKERFILE_DIR}"
 write_package_list() {
     local image_tag="$1"
     local output_file="${2}/installed-packages.txt"
-    if [[ $image_tag ~= "-cnb" ]]; then
+    if [[ $image_tag =~ "-cnb" ]]; then
       echo 'Skipping package list for CNB image'
     else
       echo '# List of packages present in the final image. Regenerate using bin/build.sh' > "$output_file"

--- a/bin/build.sh
+++ b/bin/build.sh
@@ -19,8 +19,12 @@ echo "${DOCKERFILE_DIR}"
 write_package_list() {
     local image_tag="$1"
     local output_file="${2}/installed-packages.txt"
-    echo '# List of packages present in the final image. Regenerate using bin/build.sh' > "$output_file"
-    docker run --rm "$image_tag" dpkg-query --show --showformat='${Package}\n' >> "$output_file"
+    if [[ $image_tag ~= "-cnb" ]]; then
+      echo 'Skipping package list for CNB image'
+    else
+      echo '# List of packages present in the final image. Regenerate using bin/build.sh' > "$output_file"
+      docker run --rm "$image_tag" dpkg-query --show --showformat='${Package}\n' >> "$output_file"
+    fi
 }
 
 display "Building ${STACK} main image"

--- a/heroku-18-cnb-build/Dockerfile
+++ b/heroku-18-cnb-build/Dockerfile
@@ -1,19 +1,15 @@
 FROM heroku/heroku:18-build
 
-ARG pack_uid=1000
-ARG pack_gid=1000
+RUN groupadd heroku --gid 1000 && \
+  useradd heroku -u 1000 -g 1000 -s /bin/bash -m
 
-RUN groupadd heroku --gid ${pack_gid} && \
-  useradd heroku -u ${pack_uid} -g ${pack_gid} -s /bin/bash -m
 RUN mkdir /app && \
   chown heroku:heroku /app
 
-ENV CNB_USER_ID=${pack_uid}
-ENV CNB_GROUP_ID=${pack_gid}
+ENV CNB_USER_ID=1000
+ENV CNB_GROUP_ID=1000
 
-ARG STACK="heroku-18"
-ENV STACK "${STACK}"
-ENV CNB_STACK_ID "${STACK}"
-LABEL io.buildpacks.stack.id="${STACK}"
+ENV CNB_STACK_ID "heroku-18"
+LABEL io.buildpacks.stack.id="heroku-18"
 
 USER heroku

--- a/heroku-18-cnb-build/Dockerfile
+++ b/heroku-18-cnb-build/Dockerfile
@@ -1,0 +1,19 @@
+FROM heroku/heroku:18-build
+
+ARG pack_uid=1000
+ARG pack_gid=1000
+
+RUN groupadd heroku --gid ${pack_gid} && \
+  useradd heroku -u ${pack_uid} -g ${pack_gid} -s /bin/bash -m
+RUN mkdir /app && \
+  chown heroku:heroku /app
+
+ENV CNB_USER_ID=${pack_uid}
+ENV CNB_GROUP_ID=${pack_gid}
+
+ARG STACK="heroku-18"
+ENV STACK "${STACK}"
+ENV CNB_STACK_ID "${STACK}"
+LABEL io.buildpacks.stack.id="${STACK}"
+
+USER heroku

--- a/heroku-18-cnb/Dockerfile
+++ b/heroku-18-cnb/Dockerfile
@@ -1,0 +1,13 @@
+FROM heroku/heroku:18
+
+RUN ln -s /workspace /app
+
+ARG pack_uid=1000
+ARG pack_gid=1000
+
+RUN groupadd heroku --gid ${pack_gid} && \
+  useradd heroku -u ${pack_uid} -g ${pack_gid} -s /bin/bash -m
+
+LABEL io.buildpacks.stack.id="heroku-18"
+USER heroku
+ENV HOME /app

--- a/heroku-18-cnb/Dockerfile
+++ b/heroku-18-cnb/Dockerfile
@@ -2,11 +2,8 @@ FROM heroku/heroku:18
 
 RUN ln -s /workspace /app
 
-ARG pack_uid=1000
-ARG pack_gid=1000
-
-RUN groupadd heroku --gid ${pack_gid} && \
-  useradd heroku -u ${pack_uid} -g ${pack_gid} -s /bin/bash -m
+RUN groupadd heroku --gid 1000 && \
+  useradd heroku -u 1000 -g 1000 -s /bin/bash -m
 
 LABEL io.buildpacks.stack.id="heroku-18"
 USER heroku

--- a/heroku-20-cnb-build/Dockerfile
+++ b/heroku-20-cnb-build/Dockerfile
@@ -1,0 +1,19 @@
+FROM heroku/heroku:20-build
+
+ARG pack_uid=1000
+ARG pack_gid=1000
+
+RUN groupadd heroku --gid ${pack_gid} && \
+  useradd heroku -u ${pack_uid} -g ${pack_gid} -s /bin/bash -m
+RUN mkdir /app && \
+  chown heroku:heroku /app
+
+ENV CNB_USER_ID=${pack_uid}
+ENV CNB_GROUP_ID=${pack_gid}
+
+ARG STACK="heroku-20"
+ENV STACK "${STACK}"
+ENV CNB_STACK_ID "${STACK}"
+LABEL io.buildpacks.stack.id="${STACK}"
+
+USER heroku

--- a/heroku-20-cnb-build/Dockerfile
+++ b/heroku-20-cnb-build/Dockerfile
@@ -1,19 +1,15 @@
 FROM heroku/heroku:20-build
 
-ARG pack_uid=1000
-ARG pack_gid=1000
+RUN groupadd heroku --gid 1000 && \
+  useradd heroku -u 1000 -g 1000 -s /bin/bash -m
 
-RUN groupadd heroku --gid ${pack_gid} && \
-  useradd heroku -u ${pack_uid} -g ${pack_gid} -s /bin/bash -m
 RUN mkdir /app && \
   chown heroku:heroku /app
 
-ENV CNB_USER_ID=${pack_uid}
-ENV CNB_GROUP_ID=${pack_gid}
+ENV CNB_USER_ID=1000
+ENV CNB_GROUP_ID=1000
 
-ARG STACK="heroku-20"
-ENV STACK "${STACK}"
-ENV CNB_STACK_ID "${STACK}"
-LABEL io.buildpacks.stack.id="${STACK}"
+ENV CNB_STACK_ID "heroku-20"
+LABEL io.buildpacks.stack.id="heroku-20"
 
 USER heroku

--- a/heroku-20-cnb/Dockerfile
+++ b/heroku-20-cnb/Dockerfile
@@ -1,0 +1,13 @@
+FROM heroku/heroku:20
+
+RUN ln -s /workspace /app
+
+ARG pack_uid=1000
+ARG pack_gid=1000
+
+RUN groupadd heroku --gid ${pack_gid} && \
+  useradd heroku -u ${pack_uid} -g ${pack_gid} -s /bin/bash -m
+
+LABEL io.buildpacks.stack.id="heroku-20"
+USER heroku
+ENV HOME /app

--- a/heroku-20-cnb/Dockerfile
+++ b/heroku-20-cnb/Dockerfile
@@ -2,11 +2,8 @@ FROM heroku/heroku:20
 
 RUN ln -s /workspace /app
 
-ARG pack_uid=1000
-ARG pack_gid=1000
-
-RUN groupadd heroku --gid ${pack_gid} && \
-  useradd heroku -u ${pack_uid} -g ${pack_gid} -s /bin/bash -m
+RUN groupadd heroku --gid 1000 && \
+  useradd heroku -u 1000 -g 1000 -s /bin/bash -m
 
 LABEL io.buildpacks.stack.id="heroku-20"
 USER heroku

--- a/heroku-22-cnb-build/Dockerfile
+++ b/heroku-22-cnb-build/Dockerfile
@@ -1,0 +1,19 @@
+FROM heroku/heroku:22-build
+
+ARG pack_uid=1000
+ARG pack_gid=1000
+
+RUN groupadd heroku --gid ${pack_gid} && \
+  useradd heroku -u ${pack_uid} -g ${pack_gid} -s /bin/bash -m
+RUN mkdir /app && \
+  chown heroku:heroku /app
+
+ENV CNB_USER_ID=${pack_uid}
+ENV CNB_GROUP_ID=${pack_gid}
+
+ARG STACK="heroku-22"
+ENV STACK "${STACK}"
+ENV CNB_STACK_ID "${STACK}"
+LABEL io.buildpacks.stack.id="${STACK}"
+
+USER heroku

--- a/heroku-22-cnb-build/Dockerfile
+++ b/heroku-22-cnb-build/Dockerfile
@@ -1,19 +1,15 @@
 FROM heroku/heroku:22-build
 
-ARG pack_uid=1000
-ARG pack_gid=1000
+RUN groupadd heroku --gid 1000 && \
+  useradd heroku -u 1000 -g 1000 -s /bin/bash -m
 
-RUN groupadd heroku --gid ${pack_gid} && \
-  useradd heroku -u ${pack_uid} -g ${pack_gid} -s /bin/bash -m
 RUN mkdir /app && \
   chown heroku:heroku /app
 
-ENV CNB_USER_ID=${pack_uid}
-ENV CNB_GROUP_ID=${pack_gid}
+ENV CNB_USER_ID=1000
+ENV CNB_GROUP_ID=1000
 
-ARG STACK="heroku-22"
-ENV STACK "${STACK}"
-ENV CNB_STACK_ID "${STACK}"
-LABEL io.buildpacks.stack.id="${STACK}"
+ENV CNB_STACK_ID "heroku-22"
+LABEL io.buildpacks.stack.id="heroku-22"
 
 USER heroku

--- a/heroku-22-cnb/Dockerfile
+++ b/heroku-22-cnb/Dockerfile
@@ -2,11 +2,8 @@ FROM heroku/heroku:22
 
 RUN ln -s /workspace /app
 
-ARG pack_uid=1000
-ARG pack_gid=1000
-
-RUN groupadd heroku --gid ${pack_gid} && \
-  useradd heroku -u ${pack_uid} -g ${pack_gid} -s /bin/bash -m
+RUN groupadd heroku --gid 1000 && \
+  useradd heroku -u 1000 -g 1000 -s /bin/bash -m
 
 LABEL io.buildpacks.stack.id="heroku-22"
 USER heroku

--- a/heroku-22-cnb/Dockerfile
+++ b/heroku-22-cnb/Dockerfile
@@ -1,0 +1,13 @@
+FROM heroku/heroku:22
+
+RUN ln -s /workspace /app
+
+ARG pack_uid=1000
+ARG pack_gid=1000
+
+RUN groupadd heroku --gid ${pack_gid} && \
+  useradd heroku -u ${pack_uid} -g ${pack_gid} -s /bin/bash -m
+
+LABEL io.buildpacks.stack.id="heroku-22"
+USER heroku
+ENV HOME /app


### PR DESCRIPTION
This PR introduces new images recipes and tags:

- `heroku/heroku:18-cnb`
- `heroku/heroku:18-cnb-build`
- `heroku/heroku:20-cnb`
- `heroku/heroku:20-cnb-build`
- `heroku/heroku:22-cnb`
- `heroku/heroku:22-cnb-build`

The `*-cnb` variants are CNB-compatible runtime stack images. The `*-cnb-build` variants are CNB-compatible build stack images. All of the new images are largely based on their non-cnb counterpart. These images are nearly identical to the `heroku/pack:*` images (generated in [pack-images](https://github.com/heroku/pack-images)), which we intend to replace.

GUS-W-11227981.
GUS-W-9864812.