### PR TITLE
Update year/owner in LICENSE

### DIFF
--- a/LICENSE
+++ b/LICENSE
@@ -1,4 +1,6 @@
-Copyright (c) 2015, Heroku, Inc.
+BSD 3-Clause License
+
+Copyright (c) 2022, Salesforce.com, Inc.
 All rights reserved.
 
 Redistribution and use in source and binary forms, with or without
@@ -11,11 +13,11 @@ modification, are permitted provided that the following conditions are met:
    this list of conditions and the following disclaimer in the documentation
    and/or other materials provided with the distribution.
 
-3. Neither the name of the copyright holder nor the names of its contributors
-   may be used to endorse or promote products derived from this software without
-   specific prior written permission.
+3. Neither the name of the copyright holder nor the names of its
+   contributors may be used to endorse or promote products derived from
+   this software without specific prior written permission.
 
-THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS ``AS IS''
+THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
 AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
 IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
 DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE


### PR DESCRIPTION
And also brings the file contents in line with:
https://github.com/salesforce/oss-template/blob/main/LICENSE.txt
https://github.com/heroku/buildpacks-python/blob/main/LICENSE
etc

Spotted whilst working on heroku/builder/pull/268.

GUS-W-11311287.