### PR TITLE
Apply Ubuntu Kinetic patch til backported to Jammy

### DIFF
--- a/heroku-22/setup.sh
+++ b/heroku-22/setup.sh
@@ -224,6 +224,13 @@ cat > /etc/ImageMagick-6/policy.xml <<'IMAGEMAGICK_POLICY'
 </policymap>
 IMAGEMAGICK_POLICY
 
+# until this is backported from Ubuntu kinetic to jammy, we apply by hand
+# see https://bugs.launchpad.net/ubuntu/+source/openssl/+bug/1979639 for details
+# use --force for patch to ensure it fails instead of asking for reversal once upstream has included this change
+curl -s http://archive.ubuntu.com/ubuntu/pool/main/o/openssl/openssl_3.0.4-1ubuntu1.debian.tar.xz \
+    | tar xJO debian/patches/Remove-the-provider-section.patch \
+    | patch --force /etc/ssl/openssl.cnf
+
 # Temporarily install ca-certificates-java to generate the certificates store used
 # by Java apps. Generation occurs in a post-install script which requires a JRE.
 # We're using OpenJDK 8 rather than something newer, to work around:


### PR DESCRIPTION
The Ubuntu default `/etc/ssl/openssl.cnf` file contains a section that will trigger issues with programs that link (even statically) against OpenSSL v1.

Details on the issue are documented at https://bugs.launchpad.net/ubuntu/+source/openssl/+bug/1979639

The SRU process will easily take another week or two, so until then, we're applying this patch manually.

Once it's included upstream, the patch attempt will cause the build to fail, at which point we'll remove this change again.

GUS-W-11375154