### PR TITLE
Revert "Apply Ubuntu Kinetic patch til backported to Jammy (#221)"

### DIFF
--- a/heroku-22/setup.sh
+++ b/heroku-22/setup.sh
@@ -224,13 +224,6 @@ cat > /etc/ImageMagick-6/policy.xml <<'IMAGEMAGICK_POLICY'
 </policymap>
 IMAGEMAGICK_POLICY
 
-# until this is backported from Ubuntu kinetic to jammy, we apply by hand
-# see https://bugs.launchpad.net/ubuntu/+source/openssl/+bug/1979639 for details
-# use --force for patch to ensure it fails instead of asking for reversal once upstream has included this change
-curl -s http://archive.ubuntu.com/ubuntu/pool/main/o/openssl/openssl_3.0.4-1ubuntu1.debian.tar.xz \
-    | tar xJO debian/patches/Remove-the-provider-section.patch \
-    | patch --force /etc/ssl/openssl.cnf
-
 # Temporarily install ca-certificates-java to generate the certificates store used
 # by Java apps. Generation occurs in a post-install script which requires a JRE.
 # We're using OpenJDK 8 rather than something newer, to work around:


### PR DESCRIPTION
This reverts commit d0411706785abcb8d656ecf3a3705863ec08f313.

Upstream maintainers will not port this change into Ubuntu Jammy, and there are now Node.js releases that work around this (https://nodejs.org/en/blog/vulnerability/july-2022-security-releases/).

GUS-W-11507679