### PR TITLE
Remove `pgdg-keyring` from installed packages

### DIFF
--- a/heroku-18-build/installed-packages.txt
+++ b/heroku-18-build/installed-packages.txt
@@ -514,7 +514,6 @@ patch
 perl
 perl-base
 perl-modules-5.26
-pgdg-keyring
 pinentry-curses
 pkg-config
 poppler-data

--- a/heroku-18/installed-packages.txt
+++ b/heroku-18/installed-packages.txt
@@ -309,7 +309,6 @@ patch
 perl
 perl-base
 perl-modules-5.26
-pgdg-keyring
 pinentry-curses
 poppler-data
 postgresql-client-14

--- a/heroku-20-build/installed-packages.txt
+++ b/heroku-20-build/installed-packages.txt
@@ -521,7 +521,6 @@ patch
 perl
 perl-base
 perl-modules-5.30
-pgdg-keyring
 pinentry-curses
 pkg-config
 poppler-data

--- a/heroku-20/installed-packages.txt
+++ b/heroku-20/installed-packages.txt
@@ -313,7 +313,6 @@ patch
 perl
 perl-base
 perl-modules-5.30
-pgdg-keyring
 pinentry-curses
 poppler-data
 postgresql-client-14

--- a/heroku-22-build/installed-packages.txt
+++ b/heroku-22-build/installed-packages.txt
@@ -523,7 +523,6 @@ patch
 perl
 perl-base
 perl-modules-5.34
-pgdg-keyring
 pinentry-curses
 pkg-config
 poppler-data

--- a/heroku-22/installed-packages.txt
+++ b/heroku-22/installed-packages.txt
@@ -321,7 +321,6 @@ patch
 perl
 perl-base
 perl-modules-5.34
-pgdg-keyring
 pinentry-curses
 poppler-data
 postgresql-client-14


### PR DESCRIPTION
Upstream removed the package since the way they handle the repository key changed. Nothing should change for the resulting stack image according to https://www.postgresql.org/message-id/Y25%2BRkZxiZKBOKio%40msg.df7cb.de

Closes GUS-W-12134140