### PR TITLE
Disable matrix fail-fast on GitHub Actions

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -37,6 +37,7 @@ jobs:
       MANIFEST_APP_TOKEN: "${{ secrets.MANIFEST_APP_TOKEN }}"
       MANIFEST_APP_URL: "${{ secrets.MANIFEST_APP_URL }}"
     strategy:
+      fail-fast: false
       matrix:
         stack-version: ["18", "20", "22"]
     steps:


### PR DESCRIPTION
Since otherwise any other in-progress jobs get cancelled, making it hard to see stack-specific failures in one job only affect one permutation of the matrix, or several.

https://heroku.slack.com/archives/C02GZCPPV38/p1669720178440099