### PR TITLE
add FFMPEG dependencies

### DIFF
--- a/heroku-18-build/installed-packages.txt
+++ b/heroku-18-build/installed-packages.txt
@@ -103,6 +103,7 @@ libargon2-0
 libargon2-0-dev
 libasan4
 libasn1-8-heimdal
+libass9
 libassuan0
 libatomic1
 libattr1
@@ -184,6 +185,7 @@ libfontconfig1
 libfontconfig1-dev
 libfreetype6
 libfreetype6-dev
+libfribidi0
 libgc1c2
 libgcc-7-dev
 libgcc1
@@ -319,6 +321,7 @@ libmemcached11
 libmemcachedutil2
 libmnl0
 libmount1
+libmp3lame0
 libmpc3
 libmpdec2
 libmpfr6
@@ -334,12 +337,17 @@ libnetpbm10-dev
 libnettle6
 libnghttp2-14
 libnpth0
+libnuma1
 libobjc-7-dev
 libobjc4
+libogg0
 libonig-dev
 libonig4
+libopencore-amrnb0
+libopencore-amrwb0
 libopenexr-dev
 libopenexr22
+libopus0
 libp11-kit-dev
 libp11-kit0
 libpam-modules
@@ -411,6 +419,7 @@ libsm6
 libsmartcols1
 libsodium-dev
 libsodium23
+libspeex1
 libsqlite3-0
 libss2
 libssl-dev
@@ -424,6 +433,7 @@ libtasn1-6
 libtasn1-6-dev
 libthai-data
 libthai0
+libtheora0
 libtiff-dev
 libtiff5
 libtiff5-dev
@@ -440,6 +450,9 @@ libunistring2
 libuuid1
 libuv1
 libuv1-dev
+libvorbis0a
+libvorbisenc2
+libvorbisfile3
 libvpx-dev
 libvpx5
 libwebp6
@@ -453,6 +466,8 @@ libwrap0-dev
 libx11-6
 libx11-data
 libx11-dev
+libx264-152
+libx265-146
 libxau-dev
 libxau6
 libxcb-render0

--- a/heroku-18/installed-packages.txt
+++ b/heroku-18/installed-packages.txt
@@ -40,6 +40,8 @@ gcc-7-base
 gcc-8-base
 geoip-database
 ghostscript
+gir1.2-glib-2.0
+gir1.2-harfbuzz-0.0
 git
 git-man
 gnupg
@@ -72,6 +74,7 @@ libapt-pkg5.0
 libargon2-0
 libasan4
 libasn1-8-heimdal
+libass9
 libassuan0
 libatomic1
 libattr1
@@ -125,6 +128,7 @@ libffi6
 libfftw3-double3
 libfontconfig1
 libfreetype6
+libfribidi0
 libgcc-7-dev
 libgcc1
 libgcrypt20
@@ -134,6 +138,7 @@ libgdbm5
 libgdk-pixbuf2.0-0
 libgdk-pixbuf2.0-common
 libgeoip1
+libgirepository-1.0-1
 libglib2.0-0
 libgmp10
 libgnutls-openssl27
@@ -146,6 +151,8 @@ libgs9
 libgs9-common
 libgssapi-krb5-2
 libgssapi3-heimdal
+libharfbuzz-gobject0
+libharfbuzz-icu0
 libharfbuzz0b
 libhcrypto4-heimdal
 libheimbase1-heimdal
@@ -192,6 +199,7 @@ libmcrypt4
 libmemcached11
 libmnl0
 libmount1
+libmp3lame0
 libmpc3
 libmpdec2
 libmpfr6
@@ -202,8 +210,13 @@ libncursesw5
 libnettle6
 libnghttp2-14
 libnpth0
+libnuma1
+libogg0
 libonig4
+libopencore-amrnb0
+libopencore-amrwb0
 libopenexr22
+libopus0
 libp11-kit0
 libpam-modules
 libpam-modules-bin
@@ -245,6 +258,7 @@ libsemanage1
 libsepol1
 libsmartcols1
 libsodium23
+libspeex1
 libsqlite3-0
 libss2
 libssl1.0.0
@@ -254,6 +268,7 @@ libsystemd0
 libtasn1-6
 libthai-data
 libthai0
+libtheora0
 libtiff5
 libtinfo5
 libtsan0
@@ -262,6 +277,10 @@ libudev1
 libunistring2
 libuuid1
 libuv1
+libvorbis0a
+libvorbisenc2
+libvorbisfile3
+libvpx5
 libwebp6
 libwebpdemux2
 libwebpmux3
@@ -270,6 +289,8 @@ libwmf0.2-7
 libwrap0
 libx11-6
 libx11-data
+libx264-152
+libx265-146
 libxau6
 libxcb-render0
 libxcb-shm0

--- a/heroku-18/setup.sh
+++ b/heroku-18/setup.sh
@@ -124,6 +124,7 @@ apt-get install -y --no-install-recommends \
     gcc \
     geoip-database \
     ghostscript \
+    gir1.2-harfbuzz-0.0 \
     git \
     gsfonts \
     imagemagick \
@@ -132,6 +133,7 @@ apt-get install -y --no-install-recommends \
     language-pack-en \
     less \
     libargon2-0 \
+    libass9 \
     libc-client2007e \
     libc6-dev \
     libcairo2 \
@@ -145,19 +147,31 @@ apt-get install -y --no-install-recommends \
     libevent-openssl-2.1-6 \
     libevent-pthreads-2.1-6 \
     libexif12 \
+    libfreetype6 \
+    libfribidi0 \
     libgd3 \
     libgdk-pixbuf2.0-0 \
     libgdk-pixbuf2.0-common \
     libgnutls-openssl27 \
+    libgnutls30 \
     libgnutlsxx28 \
     libgraphite2-3 \
+    libgraphite2-3 \
     libgs9 \
+    libharfbuzz-gobject0 \
+    libharfbuzz-icu0 \
     libharfbuzz0b \
     libmagickcore-6.q16-3-extra \
     libmcrypt4 \
     libmemcached11 \
+    libmp3lame0 \
     libmysqlclient20 \
+    libnuma1 \
+    libogg0 \
     libonig4 \
+    libopencore-amrnb0 \
+    libopencore-amrwb0 \
+    libopus0 \
     libpango-1.0-0 \
     libpangocairo-1.0-0 \
     libpangoft2-1.0-0 \
@@ -168,12 +182,21 @@ apt-get install -y --no-install-recommends \
     libsasl2-modules \
     libseccomp2 \
     libsodium23 \
+    libspeex1 \
     libthai-data \
     libthai0 \
+    libtheora0 \
+    libunistring2 \
     libuv1 \
+    libvorbis0a \
+    libvorbisenc2 \
+    libvorbisfile3 \
+    libvpx5 \
     libwebp6 \
     libwebpdemux2 \
     libwebpmux3 \
+    libx264-152 \
+    libx265-146 \
     libxcb-render0 \
     libxcb-shm0 \
     libxrender1 \
@@ -203,6 +226,7 @@ apt-get install -y --no-install-recommends \
     wget \
     xz-utils \
     zip \
+    zlib1g \
     zstd \
 
 

--- a/heroku-20-build/installed-packages.txt
+++ b/heroku-20-build/installed-packages.txt
@@ -64,6 +64,7 @@ ghostscript
 gir1.2-freedesktop
 gir1.2-gdkpixbuf-2.0
 gir1.2-glib-2.0
+gir1.2-harfbuzz-0.0
 gir1.2-rsvg-2.0
 git
 git-man
@@ -98,6 +99,7 @@ lib32gcc-s1
 lib32stdc++6
 libacl1
 libacl1-dev
+libaom0
 libapt-pkg-dev
 libapt-pkg6.0
 libarchive13
@@ -105,6 +107,7 @@ libargon2-1
 libargon2-dev
 libasan5
 libasn1-8-heimdal
+libass9
 libassuan0
 libatomic1
 libattr1
@@ -231,6 +234,8 @@ libgs9-common
 libgssapi-krb5-2
 libgssapi3-heimdal
 libgssrpc4
+libharfbuzz-gobject0
+libharfbuzz-icu0
 libharfbuzz0b
 libhashkit-dev
 libhashkit2
@@ -317,6 +322,7 @@ libmemcachedutil2
 libmnl0
 libmount-dev
 libmount1
+libmp3lame0
 libmpc3
 libmpdec2
 libmpfr6
@@ -333,13 +339,18 @@ libnetpbm10-dev
 libnettle7
 libnghttp2-14
 libnpth0
+libnuma1
 libobjc-9-dev
 libobjc4
+libogg0
 libonig-dev
 libonig5
+libopencore-amrnb0
+libopencore-amrwb0
 libopenexr-dev
 libopenexr24
 libopenjp2-7
+libopus0
 libp11-kit-dev
 libp11-kit0
 libpam-modules
@@ -416,6 +427,7 @@ libsm6
 libsmartcols1
 libsodium-dev
 libsodium23
+libspeex1
 libsqlite3-0
 libss2
 libssh-4
@@ -429,6 +441,7 @@ libtasn1-6
 libtasn1-6-dev
 libthai-data
 libthai0
+libtheora0
 libtiff-dev
 libtiff5
 libtiffxx5
@@ -443,6 +456,9 @@ libunistring2
 libuuid1
 libuv1
 libuv1-dev
+libvorbis0a
+libvorbisenc2
+libvorbisfile3
 libvpx-dev
 libvpx6
 libwebp6
@@ -456,6 +472,8 @@ libwrap0-dev
 libx11-6
 libx11-data
 libx11-dev
+libx264-155
+libx265-179
 libxau-dev
 libxau6
 libxcb-render0

--- a/heroku-20/installed-packages.txt
+++ b/heroku-20/installed-packages.txt
@@ -43,6 +43,8 @@ gcc-9
 gcc-9-base
 geoip-database
 ghostscript
+gir1.2-glib-2.0
+gir1.2-harfbuzz-0.0
 git
 git-man
 gnupg
@@ -70,10 +72,12 @@ language-pack-en
 language-pack-en-base
 less
 libacl1
+libaom0
 libapt-pkg6.0
 libargon2-1
 libasan5
 libasn1-8-heimdal
+libass9
 libassuan0
 libatomic1
 libattr1
@@ -141,6 +145,7 @@ libgdbm-compat4
 libgdbm6
 libgdk-pixbuf2.0-0
 libgdk-pixbuf2.0-common
+libgirepository-1.0-1
 libglib2.0-0
 libgmp10
 libgnutls-openssl27
@@ -153,6 +158,8 @@ libgs9
 libgs9-common
 libgssapi-krb5-2
 libgssapi3-heimdal
+libharfbuzz-gobject0
+libharfbuzz-icu0
 libharfbuzz0b
 libhcrypto4-heimdal
 libheimbase1-heimdal
@@ -197,6 +204,7 @@ libmcrypt4
 libmemcached11
 libmnl0
 libmount1
+libmp3lame0
 libmpc3
 libmpdec2
 libmpfr6
@@ -206,9 +214,14 @@ libncursesw6
 libnettle7
 libnghttp2-14
 libnpth0
+libnuma1
+libogg0
 libonig5
+libopencore-amrnb0
+libopencore-amrwb0
 libopenexr24
 libopenjp2-7
+libopus0
 libp11-kit0
 libpam-modules
 libpam-modules-bin
@@ -248,6 +261,7 @@ libsemanage1
 libsepol1
 libsmartcols1
 libsodium23
+libspeex1
 libsqlite3-0
 libss2
 libssh-4
@@ -257,6 +271,7 @@ libsystemd0
 libtasn1-6
 libthai-data
 libthai0
+libtheora0
 libtiff5
 libtinfo6
 libtsan0
@@ -265,6 +280,10 @@ libudev1
 libunistring2
 libuuid1
 libuv1
+libvorbis0a
+libvorbisenc2
+libvorbisfile3
+libvpx6
 libwebp6
 libwebpdemux2
 libwebpmux3
@@ -273,6 +292,8 @@ libwmf0.2-7
 libwrap0
 libx11-6
 libx11-data
+libx264-155
+libx265-179
 libxau6
 libxcb-render0
 libxcb-shm0

--- a/heroku-20/setup.sh
+++ b/heroku-20/setup.sh
@@ -124,6 +124,7 @@ apt-get install -y --no-install-recommends \
     gcc \
     geoip-database \
     ghostscript \
+    gir1.2-harfbuzz-0.0 \
     git \
     gsfonts \
     imagemagick \
@@ -131,7 +132,9 @@ apt-get install -y --no-install-recommends \
     iputils-tracepath \
     language-pack-en \
     less \
+    libaom0 \
     libargon2-1 \
+    libass9 \
     libc-client2007e \
     libc6-dev \
     libcairo2 \
@@ -145,20 +148,32 @@ apt-get install -y --no-install-recommends \
     libevent-openssl-2.1-7 \
     libevent-pthreads-2.1-7 \
     libexif12 \
+    libfreetype6 \
+    libfribidi0 \
     libgd3 \
     libgdk-pixbuf2.0-0 \
     libgdk-pixbuf2.0-common \
     libgnutls-openssl27 \
+    libgnutls30 \
     libgnutlsxx28 \
     libgraphite2-3 \
+    libgraphite2-3 \
     libgs9 \
+    libharfbuzz-gobject0 \
+    libharfbuzz-icu0 \
     libharfbuzz0b \
     liblzf1 \
     libmagickcore-6.q16-3-extra \
     libmcrypt4 \
     libmemcached11 \
+    libmp3lame0 \
     libmysqlclient21 \
+    libnuma1 \
+    libogg0 \
     libonig5 \
+    libopencore-amrnb0 \
+    libopencore-amrwb0 \
+    libopus0 \
     libpango-1.0-0 \
     libpangocairo-1.0-0 \
     libpangoft2-1.0-0 \
@@ -169,12 +184,21 @@ apt-get install -y --no-install-recommends \
     libsasl2-modules \
     libseccomp2 \
     libsodium23 \
+    libspeex1 \
     libthai-data \
     libthai0 \
+    libtheora0 \
+    libunistring2 \
     libuv1 \
+    libvorbis0a \
+    libvorbisenc2 \
+    libvorbisfile3 \
+    libvpx6 \
     libwebp6 \
     libwebpdemux2 \
     libwebpmux3 \
+    libx264-155 \
+    libx265-179 \
     libxcb-render0 \
     libxcb-shm0 \
     libxrender1 \
@@ -205,6 +229,7 @@ apt-get install -y --no-install-recommends \
     wget \
     xz-utils \
     zip \
+    zlib1g \
     zstd \
 
 

--- a/heroku-22-build/installed-packages.txt
+++ b/heroku-22-build/installed-packages.txt
@@ -63,6 +63,7 @@ ghostscript
 gir1.2-freedesktop
 gir1.2-gdkpixbuf-2.0
 gir1.2-glib-2.0
+gir1.2-harfbuzz-0.0
 gir1.2-rsvg-2.0
 git
 git-man
@@ -104,6 +105,7 @@ libarchive13
 libargon2-1
 libargon2-dev
 libasan6
+libass9
 libassuan0
 libatomic1
 libattr1
@@ -235,6 +237,8 @@ libgs9
 libgs9-common
 libgssapi-krb5-2
 libgssrpc4
+libharfbuzz-gobject0
+libharfbuzz-icu0
 libharfbuzz0b
 libhashkit-dev
 libhashkit2
@@ -323,6 +327,7 @@ libmemcachedutil2
 libmnl0
 libmount-dev
 libmount1
+libmp3lame0
 libmpc3
 libmpdec3
 libmpfr6
@@ -342,12 +347,16 @@ libnpth0
 libnsl-dev
 libnsl2
 libnuma1
+libogg0
 libonig-dev
 libonig5
+libopencore-amrnb0
+libopencore-amrwb0
 libopenexr-dev
 libopenexr25
 libopenjp2-7
 libopenjp2-7-dev
+libopus0
 libp11-kit-dev
 libp11-kit0
 libpam-modules
@@ -417,6 +426,7 @@ libsm6
 libsmartcols1
 libsodium-dev
 libsodium23
+libspeex1
 libsqlite3-0
 libss2
 libssh-4
@@ -424,12 +434,14 @@ libssl-dev
 libssl3
 libstdc++-11-dev
 libstdc++6
+libsvtav1enc0
 libsystemd-dev
 libsystemd0
 libtasn1-6
 libtasn1-6-dev
 libthai-data
 libthai0
+libtheora0
 libtiff-dev
 libtiff5
 libtiffxx5
@@ -447,6 +459,9 @@ libunistring2
 libuuid1
 libuv1
 libuv1-dev
+libvorbis0a
+libvorbisenc2
+libvorbisfile3
 libvpx-dev
 libvpx7
 libwebp7
@@ -460,6 +475,7 @@ libwrap0-dev
 libx11-6
 libx11-data
 libx11-dev
+libx264-163
 libx265-199
 libx265-dev
 libxau-dev

--- a/heroku-22/installed-packages.txt
+++ b/heroku-22/installed-packages.txt
@@ -42,6 +42,8 @@ gcc-11-base
 gcc-12-base
 geoip-database
 ghostscript
+gir1.2-glib-2.0
+gir1.2-harfbuzz-0.0
 git
 git-man
 gnupg
@@ -74,6 +76,7 @@ libapparmor1
 libapt-pkg6.0
 libargon2-1
 libasan6
+libass9
 libassuan0
 libatomic1
 libattr1
@@ -147,6 +150,7 @@ libgdk-pixbuf-2.0-0
 libgdk-pixbuf-xlib-2.0-0
 libgdk-pixbuf2.0-0
 libgdk-pixbuf2.0-common
+libgirepository-1.0-1
 libglib2.0-0
 libgmp10
 libgnutls-openssl27
@@ -158,6 +162,8 @@ libgraphite2-3
 libgs9
 libgs9-common
 libgssapi-krb5-2
+libharfbuzz-gobject0
+libharfbuzz-icu0
 libharfbuzz0b
 libheif1
 libhogweed6
@@ -200,6 +206,7 @@ libmd0
 libmemcached11
 libmnl0
 libmount1
+libmp3lame0
 libmpc3
 libmpdec3
 libmpfr6
@@ -212,9 +219,13 @@ libnpth0
 libnsl-dev
 libnsl2
 libnuma1
+libogg0
 libonig5
+libopencore-amrnb0
+libopencore-amrwb0
 libopenexr25
 libopenjp2-7
+libopus0
 libp11-kit0
 libpam-modules
 libpam-modules-bin
@@ -252,15 +263,18 @@ libsemanage2
 libsepol2
 libsmartcols1
 libsodium23
+libspeex1
 libsqlite3-0
 libss2
 libssh-4
 libssl3
 libstdc++6
+libsvtav1enc0
 libsystemd0
 libtasn1-6
 libthai-data
 libthai0
+libtheora0
 libtiff5
 libtinfo6
 libtirpc-common
@@ -272,6 +286,10 @@ libudev1
 libunistring2
 libuuid1
 libuv1
+libvorbis0a
+libvorbisenc2
+libvorbisfile3
+libvpx7
 libwebp7
 libwebpdemux2
 libwebpmux3
@@ -279,6 +297,7 @@ libwmflite-0.2-7
 libwrap0
 libx11-6
 libx11-data
+libx264-163
 libx265-199
 libxau6
 libxcb-render0

--- a/heroku-22/setup.sh
+++ b/heroku-22/setup.sh
@@ -124,6 +124,7 @@ apt-get install -y --no-install-recommends \
     gcc \
     geoip-database \
     ghostscript \
+    gir1.2-harfbuzz-0.0 \
     git \
     gsfonts \
     imagemagick \
@@ -131,12 +132,15 @@ apt-get install -y --no-install-recommends \
     iputils-tracepath \
     language-pack-en \
     less \
+    libaom3 \
     libargon2-1 \
+    libass9 \
     libc-client2007e \
     libc6-dev \
     libcairo2 \
     libcurl4 \
     libdatrie1 \
+    libdav1d5 \
     libev4 \
     libevent-2.1-7 \
     libevent-core-2.1-7 \
@@ -144,21 +148,33 @@ apt-get install -y --no-install-recommends \
     libevent-openssl-2.1-7 \
     libevent-pthreads-2.1-7 \
     libexif12 \
+    libfreetype6 \
+    libfribidi0 \
     libgd3 \
     libgdk-pixbuf2.0-0 \
     libgdk-pixbuf2.0-common \
     libgnutls-openssl27 \
+    libgnutls30 \
     libgnutlsxx28 \
     libgraphite2-3 \
+    libgraphite2-3 \
     libgs9 \
+    libharfbuzz-gobject0 \
+    libharfbuzz-icu0 \
     libharfbuzz0b \
     libheif1 \
     liblzf1 \
     libmagickcore-6.q16-3-extra \
     libmcrypt4 \
     libmemcached11 \
+    libmp3lame0 \
     libmysqlclient21 \
+    libnuma1 \
+    libogg0 \
     libonig5 \
+    libopencore-amrnb0 \
+    libopencore-amrwb0 \
+    libopus0 \
     libpango-1.0-0 \
     libpangocairo-1.0-0 \
     libpangoft2-1.0-0 \
@@ -169,12 +185,22 @@ apt-get install -y --no-install-recommends \
     libsasl2-modules \
     libseccomp2 \
     libsodium23 \
+    libspeex1 \
+    libsvtav1enc0 \
     libthai-data \
     libthai0 \
+    libtheora0 \
+    libunistring2 \
     libuv1 \
+    libvorbis0a \
+    libvorbisenc2 \
+    libvorbisfile3 \
+    libvpx7 \
     libwebp7 \
     libwebpdemux2 \
     libwebpmux3 \
+    libx264-163 \
+    libx265-199 \
     libxcb-render0 \
     libxcb-shm0 \
     libxrender1 \
@@ -205,6 +231,7 @@ apt-get install -y --no-install-recommends \
     wget \
     xz-utils \
     zip \
+    zlib1g \
     zstd \
 
 


### PR DESCRIPTION
To support https://github.com/heroku/heroku-buildpack-activestorage-preview/pull/28

## Size impact on stack image

```
heroku/heroku:18.v97                                  512MB
heroku/heroku:18                                      532MB

heroku/heroku:20.v97                                  581MB
heroku/heroku:20                                      610MB

heroku/heroku:22.v97                                  620MB
heroku/heroku:22                                      634MB
```

### Detailed breakdown

Base libraries for common codecs:
```
# apt-get install -y --no-install-recommends gir1.2-harfbuzz-0.0 libass9 libfreetype6 libfribidi0 libgraphite2-3 libgnutls30 libharfbuzz-gobject0 libharfbuzz-icu0 libharfbuzz0b libmp3lame0 libogg0 libunistring2 libvorbis0a libvorbisenc2 libvorbisfile3 zlib1g libnuma1 libopus0 libx264-163 libx265-199 libvpx7
…
The following NEW packages will be installed:
  gir1.2-glib-2.0 gir1.2-harfbuzz-0.0 libass9 libgirepository-1.0-1
  libharfbuzz-gobject0 libharfbuzz-icu0 libmp3lame0 libogg0 libopus0
  libvorbis0a libvorbisenc2 libvorbisfile3 libvpx7 libx264-163
0 upgraded, 14 newly installed, 0 to remove and 0 not upgraded.
Need to get 2616 kB of archives.
After this operation, 8293 kB of additional disk space will be used.
…
```

`libaom` is already on heroku-22:
```
# apt-get install -y --no-install-recommends libaom3
…
libaom3 is already the newest version (3.3.0-1).
libaom3 set to manually installed.
0 upgraded, 0 newly installed, 0 to remove and 0 not upgraded.
```

`libdav1d` is already on `heroku-22`:
```
# apt-get install -y --no-install-recommends libdav1d5
…
libdav1d5 is already the newest version (0.9.2-1).
libdav1d5 set to manually installed.
0 upgraded, 0 newly installed, 0 to remove and 0 not upgraded.
```

`libsvtav1enc`:
```
# apt-get install -y --no-install-recommends libsvtav1enc0
…
The following NEW packages will be installed:
  libsvtav1enc0
0 upgraded, 1 newly installed, 0 to remove and 0 not upgraded.
Need to get 1615 kB of archives.
After this operation, 4699 kB of additional disk space will be used.
…
```

OpenCore codecs:
```
# apt-get install --no-install-recommends libopencore-amrnb0 libopencore-amrwb0
…
The following NEW packages will be installed:
  libopencore-amrnb0 libopencore-amrwb0
0 upgraded, 2 newly installed, 0 to remove and 0 not upgraded.
Need to get 144 kB of archives.
After this operation, 299 kB of additional disk space will be used.
…
```

Speex:
```
# apt-get install -y --no-install-recommends libspeex1    
…
The following NEW packages will be installed:
  libspeex1
0 upgraded, 1 newly installed, 0 to remove and 0 not upgraded.
Need to get 57.9 kB of archives.
After this operation, 137 kB of additional disk space will be used.
…
```

Theora:
```
# apt-get install -y --no-install-recommends libtheora0
…
The following NEW packages will be installed:
  libtheora0
0 upgraded, 1 newly installed, 0 to remove and 0 not upgraded.
Need to get 209 kB of archives.
After this operation, 667 kB of additional disk space will be used.
…
```

OpenCore, Speex and Theora are for parity with the previous SFFMPEG. Unsure how relevant they are really for previewing anything, but the size impact isn't significant.

`libsvtav1enc` is a bit chunkier; it's the SVT-AV1 encoder, which is AOM's new "standard" encoder that future AV1 research is based on. Obviously, for ActiveStorage Preview, which only grabs still images from a video, an AV1 encoder (or any other video encoder) wouldn't be necessary, so we could leave that package out.

On the other hand, producing a reasonably universal FFMPEG binary that's more or less at parity with the not-well-maintained SFFMPEG and which can be used for purposes other than ActiveStorage Preview is useful, too.

---

GUS-W-12579924