### PR TITLE
Add libvips and poppler-utils

### DIFF
--- a/heroku-18-build/installed-packages.txt
+++ b/heroku-18-build/installed-packages.txt
@@ -95,6 +95,7 @@ lib32gcc1
 lib32stdc++6
 libacl1
 libacl1-dev
+libaec0
 libapt-inst2.0
 libapt-pkg-dev
 libapt-pkg5.0
@@ -138,6 +139,7 @@ libcap-ng-dev
 libcap-ng0
 libcap2
 libcc1-0
+libcfitsio5
 libcilkrts5
 libclang-common-6.0-dev
 libclang1-6.0
@@ -201,6 +203,8 @@ libgdk-pixbuf2.0-common
 libgdk-pixbuf2.0-dev
 libgeoip-dev
 libgeoip1
+libgfortran4
+libgif7
 libgirepository-1.0-1
 libglib2.0-0
 libglib2.0-bin
@@ -223,6 +227,8 @@ libgraphite2-dev
 libgs-dev
 libgs9
 libgs9-common
+libgsf-1-114
+libgsf-1-common
 libgssapi-krb5-2
 libgssapi3-heimdal
 libgssrpc4
@@ -233,6 +239,7 @@ libharfbuzz0b
 libhashkit-dev
 libhashkit2
 libhcrypto4-heimdal
+libhdf5-100
 libheimbase1-heimdal
 libheimntlm0-heimdal
 libhogweed4
@@ -314,6 +321,7 @@ libmagickwand-6-headers
 libmagickwand-6.q16-3
 libmagickwand-6.q16-dev
 libmagickwand-dev
+libmatio4
 libmcrypt-dev
 libmcrypt4
 libmemcached-dev
@@ -337,6 +345,8 @@ libnetpbm10-dev
 libnettle6
 libnghttp2-14
 libnpth0
+libnspr4
+libnss3
 libnuma1
 libobjc-7-dev
 libobjc4
@@ -347,7 +357,10 @@ libopencore-amrnb0
 libopencore-amrwb0
 libopenexr-dev
 libopenexr22
+libopenjp2-7
+libopenslide0
 libopus0
+liborc-0.4-0
 libp11-kit-dev
 libp11-kit0
 libpam-modules
@@ -371,6 +384,8 @@ libpixman-1-0
 libpixman-1-dev
 libpng-dev
 libpng16-16
+libpoppler-glib8
+libpoppler73
 libpopt-dev
 libpopt0
 libpq-dev
@@ -429,6 +444,7 @@ libstdc++-7-dev
 libstdc++6
 libsystemd-dev
 libsystemd0
+libsz2
 libtasn1-6
 libtasn1-6-dev
 libthai-data
@@ -450,6 +466,7 @@ libunistring2
 libuuid1
 libuv1
 libuv1-dev
+libvips42
 libvorbis0a
 libvorbisenc2
 libvorbisfile3

--- a/heroku-18-build/installed-packages.txt
+++ b/heroku-18-build/installed-packages.txt
@@ -549,6 +549,7 @@ perl-modules-5.26
 pinentry-curses
 pkg-config
 poppler-data
+poppler-utils
 postgresql-client-15
 postgresql-client-common
 postgresql-common

--- a/heroku-18/installed-packages.txt
+++ b/heroku-18/installed-packages.txt
@@ -69,6 +69,7 @@ language-pack-en
 language-pack-en-base
 less
 libacl1
+libaec0
 libapt-inst2.0
 libapt-pkg5.0
 libargon2-0
@@ -97,6 +98,7 @@ libcairo2
 libcap-ng0
 libcap2
 libcc1-0
+libcfitsio5
 libcilkrts5
 libcom-err2
 libcroco3
@@ -138,6 +140,8 @@ libgdbm5
 libgdk-pixbuf2.0-0
 libgdk-pixbuf2.0-common
 libgeoip1
+libgfortran4
+libgif7
 libgirepository-1.0-1
 libglib2.0-0
 libgmp10
@@ -149,12 +153,15 @@ libgpg-error0
 libgraphite2-3
 libgs9
 libgs9-common
+libgsf-1-114
+libgsf-1-common
 libgssapi-krb5-2
 libgssapi3-heimdal
 libharfbuzz-gobject0
 libharfbuzz-icu0
 libharfbuzz0b
 libhcrypto4-heimdal
+libhdf5-100
 libheimbase1-heimdal
 libheimntlm0-heimdal
 libhogweed4
@@ -195,6 +202,7 @@ libmagic1
 libmagickcore-6.q16-3
 libmagickcore-6.q16-3-extra
 libmagickwand-6.q16-3
+libmatio4
 libmcrypt4
 libmemcached11
 libmnl0
@@ -210,13 +218,18 @@ libncursesw5
 libnettle6
 libnghttp2-14
 libnpth0
+libnspr4
+libnss3
 libnuma1
 libogg0
 libonig4
 libopencore-amrnb0
 libopencore-amrwb0
 libopenexr22
+libopenjp2-7
+libopenslide0
 libopus0
+liborc-0.4-0
 libp11-kit0
 libpam-modules
 libpam-modules-bin
@@ -230,6 +243,8 @@ libpcre3
 libperl5.26
 libpixman-1-0
 libpng16-16
+libpoppler-glib8
+libpoppler73
 libpopt0
 libpq5
 libprocps6
@@ -265,6 +280,7 @@ libssl1.0.0
 libssl1.1
 libstdc++6
 libsystemd0
+libsz2
 libtasn1-6
 libthai-data
 libthai0
@@ -277,6 +293,7 @@ libudev1
 libunistring2
 libuuid1
 libuv1
+libvips42
 libvorbis0a
 libvorbisenc2
 libvorbisfile3

--- a/heroku-18/installed-packages.txt
+++ b/heroku-18/installed-packages.txt
@@ -349,6 +349,7 @@ perl-base
 perl-modules-5.26
 pinentry-curses
 poppler-data
+poppler-utils
 postgresql-client-15
 postgresql-client-common
 procps

--- a/heroku-18/setup.sh
+++ b/heroku-18/setup.sh
@@ -211,6 +211,7 @@ apt-get install -y --no-install-recommends \
     openssh-client \
     openssh-server \
     patch \
+    poppler-utils \
     postgresql-client-15 \
     python \
     rename \

--- a/heroku-18/setup.sh
+++ b/heroku-18/setup.sh
@@ -188,6 +188,7 @@ apt-get install -y --no-install-recommends \
     libtheora0 \
     libunistring2 \
     libuv1 \
+    libvips42 \
     libvorbis0a \
     libvorbisenc2 \
     libvorbisfile3 \

--- a/heroku-20-build/installed-packages.txt
+++ b/heroku-20-build/installed-packages.txt
@@ -560,6 +560,7 @@ perl-modules-5.30
 pinentry-curses
 pkg-config
 poppler-data
+poppler-utils
 postgresql-client-15
 postgresql-client-common
 postgresql-common

--- a/heroku-20-build/installed-packages.txt
+++ b/heroku-20-build/installed-packages.txt
@@ -99,6 +99,7 @@ lib32gcc-s1
 lib32stdc++6
 libacl1
 libacl1-dev
+libaec0
 libaom0
 libapt-pkg-dev
 libapt-pkg6.0
@@ -144,6 +145,7 @@ libcap2
 libcap2-bin
 libcbor0.6
 libcc1-0
+libcfitsio8
 libclang-common-10-dev
 libclang-cpp10
 libclang1-10
@@ -210,6 +212,8 @@ libgdk-pixbuf2.0-common
 libgdk-pixbuf2.0-dev
 libgeoip-dev
 libgeoip1
+libgfortran5
+libgif7
 libgirepository-1.0-1
 libglib2.0-0
 libglib2.0-bin
@@ -231,6 +235,8 @@ libgraphite2-3
 libgs-dev
 libgs9
 libgs9-common
+libgsf-1-114
+libgsf-1-common
 libgssapi-krb5-2
 libgssapi3-heimdal
 libgssrpc4
@@ -240,6 +246,7 @@ libharfbuzz0b
 libhashkit-dev
 libhashkit2
 libhcrypto4-heimdal
+libhdf5-103
 libheimbase1-heimdal
 libheimntlm0-heimdal
 libhogweed5
@@ -255,6 +262,7 @@ libidn2-dev
 libijs-0.35
 libilmbase-dev
 libilmbase24
+libimagequant0
 libisl22
 libitm1
 libjbig-dev
@@ -313,6 +321,7 @@ libmagickwand-6-headers
 libmagickwand-6.q16-6
 libmagickwand-6.q16-dev
 libmagickwand-dev
+libmatio9
 libmaxminddb0
 libmcrypt-dev
 libmcrypt4
@@ -339,6 +348,8 @@ libnetpbm10-dev
 libnettle7
 libnghttp2-14
 libnpth0
+libnspr4
+libnss3
 libnuma1
 libobjc-9-dev
 libobjc4
@@ -350,7 +361,9 @@ libopencore-amrwb0
 libopenexr-dev
 libopenexr24
 libopenjp2-7
+libopenslide0
 libopus0
+liborc-0.4-0
 libp11-kit-dev
 libp11-kit0
 libpam-modules
@@ -379,6 +392,8 @@ libpixman-1-0
 libpixman-1-dev
 libpng-dev
 libpng16-16
+libpoppler-glib8
+libpoppler97
 libpopt-dev
 libpopt0
 libpq-dev
@@ -437,6 +452,7 @@ libstdc++-9-dev
 libstdc++6
 libsystemd-dev
 libsystemd0
+libsz2
 libtasn1-6
 libtasn1-6-dev
 libthai-data
@@ -456,6 +472,7 @@ libunistring2
 libuuid1
 libuv1
 libuv1-dev
+libvips42
 libvorbis0a
 libvorbisenc2
 libvorbisfile3

--- a/heroku-20/installed-packages.txt
+++ b/heroku-20/installed-packages.txt
@@ -353,6 +353,7 @@ perl-base
 perl-modules-5.30
 pinentry-curses
 poppler-data
+poppler-utils
 postgresql-client-15
 postgresql-client-common
 procps

--- a/heroku-20/installed-packages.txt
+++ b/heroku-20/installed-packages.txt
@@ -72,6 +72,7 @@ language-pack-en
 language-pack-en-base
 less
 libacl1
+libaec0
 libaom0
 libapt-pkg6.0
 libargon2-1
@@ -103,6 +104,7 @@ libcap2
 libcap2-bin
 libcbor0.6
 libcc1-0
+libcfitsio8
 libcom-err2
 libcroco3
 libcrypt-dev
@@ -145,6 +147,8 @@ libgdbm-compat4
 libgdbm6
 libgdk-pixbuf2.0-0
 libgdk-pixbuf2.0-common
+libgfortran5
+libgif7
 libgirepository-1.0-1
 libglib2.0-0
 libgmp10
@@ -156,12 +160,15 @@ libgpg-error0
 libgraphite2-3
 libgs9
 libgs9-common
+libgsf-1-114
+libgsf-1-common
 libgssapi-krb5-2
 libgssapi3-heimdal
 libharfbuzz-gobject0
 libharfbuzz-icu0
 libharfbuzz0b
 libhcrypto4-heimdal
+libhdf5-103
 libheimbase1-heimdal
 libheimntlm0-heimdal
 libhogweed5
@@ -171,6 +178,7 @@ libidn11
 libidn2-0
 libijs-0.35
 libilmbase24
+libimagequant0
 libisl22
 libitm1
 libjbig0
@@ -199,6 +207,7 @@ libmagic1
 libmagickcore-6.q16-6
 libmagickcore-6.q16-6-extra
 libmagickwand-6.q16-6
+libmatio9
 libmaxminddb0
 libmcrypt4
 libmemcached11
@@ -214,6 +223,8 @@ libncursesw6
 libnettle7
 libnghttp2-14
 libnpth0
+libnspr4
+libnss3
 libnuma1
 libogg0
 libonig5
@@ -221,7 +232,9 @@ libopencore-amrnb0
 libopencore-amrwb0
 libopenexr24
 libopenjp2-7
+libopenslide0
 libopus0
+liborc-0.4-0
 libp11-kit0
 libpam-modules
 libpam-modules-bin
@@ -236,6 +249,8 @@ libpcre3
 libperl5.30
 libpixman-1-0
 libpng16-16
+libpoppler-glib8
+libpoppler97
 libpopt0
 libpq5
 libprocps8
@@ -268,6 +283,7 @@ libssh-4
 libssl1.1
 libstdc++6
 libsystemd0
+libsz2
 libtasn1-6
 libthai-data
 libthai0
@@ -280,6 +296,7 @@ libudev1
 libunistring2
 libuuid1
 libuv1
+libvips42
 libvorbis0a
 libvorbisenc2
 libvorbisfile3

--- a/heroku-20/setup.sh
+++ b/heroku-20/setup.sh
@@ -213,6 +213,7 @@ apt-get install -y --no-install-recommends \
     openssh-client \
     openssh-server \
     patch \
+    poppler-utils \
     postgresql-client-15 \
     python-is-python3 \
     python3 \

--- a/heroku-20/setup.sh
+++ b/heroku-20/setup.sh
@@ -190,6 +190,7 @@ apt-get install -y --no-install-recommends \
     libtheora0 \
     libunistring2 \
     libuv1 \
+    libvips42 \
     libvorbis0a \
     libvorbisenc2 \
     libvorbisfile3 \

--- a/heroku-22-build/installed-packages.txt
+++ b/heroku-22-build/installed-packages.txt
@@ -559,6 +559,7 @@ perl-modules-5.34
 pinentry-curses
 pkg-config
 poppler-data
+poppler-utils
 postgresql-client-15
 postgresql-client-common
 procps

--- a/heroku-22-build/installed-packages.txt
+++ b/heroku-22-build/installed-packages.txt
@@ -96,6 +96,7 @@ language-pack-en-base
 less
 libacl1
 libacl1-dev
+libaec0
 libaom-dev
 libaom3
 libapparmor1
@@ -143,6 +144,8 @@ libcap2
 libcap2-bin
 libcbor0.8
 libcc1-0
+libcfitsio9
+libcgif0
 libcom-err2
 libcrypt-dev
 libcrypt1
@@ -235,6 +238,8 @@ libgraphite2-3
 libgs-dev
 libgs9
 libgs9-common
+libgsf-1-114
+libgsf-1-common
 libgssapi-krb5-2
 libgssrpc4
 libharfbuzz-gobject0
@@ -242,6 +247,7 @@ libharfbuzz-icu0
 libharfbuzz0b
 libhashkit-dev
 libhashkit2
+libhdf5-103-1
 libheif-dev
 libheif1
 libhogweed6
@@ -257,6 +263,7 @@ libidn2-dev
 libijs-0.35
 libilmbase-dev
 libilmbase25
+libimagequant0
 libip4tc2
 libisl23
 libitm1
@@ -316,6 +323,7 @@ libmagickwand-6-headers
 libmagickwand-6.q16-6
 libmagickwand-6.q16-dev
 libmagickwand-dev
+libmatio11
 libmaxminddb0
 libmcrypt-dev
 libmcrypt4
@@ -346,6 +354,8 @@ libnghttp2-14
 libnpth0
 libnsl-dev
 libnsl2
+libnspr4
+libnss3
 libnuma1
 libogg0
 libonig-dev
@@ -356,7 +366,9 @@ libopenexr-dev
 libopenexr25
 libopenjp2-7
 libopenjp2-7-dev
+libopenslide0
 libopus0
+liborc-0.4-0
 libp11-kit-dev
 libp11-kit0
 libpam-modules
@@ -383,6 +395,8 @@ libpixman-1-0
 libpixman-1-dev
 libpng-dev
 libpng16-16
+libpoppler-glib8
+libpoppler118
 libpopt-dev
 libpopt0
 libpq-dev
@@ -437,6 +451,7 @@ libstdc++6
 libsvtav1enc0
 libsystemd-dev
 libsystemd0
+libsz2
 libtasn1-6
 libtasn1-6-dev
 libthai-data
@@ -459,6 +474,7 @@ libunistring2
 libuuid1
 libuv1
 libuv1-dev
+libvips42
 libvorbis0a
 libvorbisenc2
 libvorbisfile3

--- a/heroku-22/installed-packages.txt
+++ b/heroku-22/installed-packages.txt
@@ -358,6 +358,7 @@ perl-base
 perl-modules-5.34
 pinentry-curses
 poppler-data
+poppler-utils
 postgresql-client-15
 postgresql-client-common
 procps

--- a/heroku-22/installed-packages.txt
+++ b/heroku-22/installed-packages.txt
@@ -71,6 +71,7 @@ language-pack-en
 language-pack-en-base
 less
 libacl1
+libaec0
 libaom3
 libapparmor1
 libapt-pkg6.0
@@ -103,6 +104,8 @@ libcap2
 libcap2-bin
 libcbor0.8
 libcc1-0
+libcfitsio9
+libcgif0
 libcom-err2
 libcrypt-dev
 libcrypt1
@@ -161,10 +164,13 @@ libgpg-error0
 libgraphite2-3
 libgs9
 libgs9-common
+libgsf-1-114
+libgsf-1-common
 libgssapi-krb5-2
 libharfbuzz-gobject0
 libharfbuzz-icu0
 libharfbuzz0b
+libhdf5-103-1
 libheif1
 libhogweed6
 libicu70
@@ -172,6 +178,7 @@ libidn12
 libidn2-0
 libijs-0.35
 libilmbase25
+libimagequant0
 libip4tc2
 libisl23
 libitm1
@@ -200,6 +207,7 @@ libmagic1
 libmagickcore-6.q16-6
 libmagickcore-6.q16-6-extra
 libmagickwand-6.q16-6
+libmatio11
 libmaxminddb0
 libmcrypt4
 libmd0
@@ -218,6 +226,8 @@ libnghttp2-14
 libnpth0
 libnsl-dev
 libnsl2
+libnspr4
+libnss3
 libnuma1
 libogg0
 libonig5
@@ -225,7 +235,9 @@ libopencore-amrnb0
 libopencore-amrwb0
 libopenexr25
 libopenjp2-7
+libopenslide0
 libopus0
+liborc-0.4-0
 libp11-kit0
 libpam-modules
 libpam-modules-bin
@@ -240,6 +252,8 @@ libpcre3
 libperl5.34
 libpixman-1-0
 libpng16-16
+libpoppler-glib8
+libpoppler118
 libpopt0
 libpq5
 libprocps8
@@ -271,6 +285,7 @@ libssl3
 libstdc++6
 libsvtav1enc0
 libsystemd0
+libsz2
 libtasn1-6
 libthai-data
 libthai0
@@ -286,6 +301,7 @@ libudev1
 libunistring2
 libuuid1
 libuv1
+libvips42
 libvorbis0a
 libvorbisenc2
 libvorbisfile3

--- a/heroku-22/setup.sh
+++ b/heroku-22/setup.sh
@@ -192,6 +192,7 @@ apt-get install -y --no-install-recommends \
     libtheora0 \
     libunistring2 \
     libuv1 \
+    libvips42 \
     libvorbis0a \
     libvorbisenc2 \
     libvorbisfile3 \

--- a/heroku-22/setup.sh
+++ b/heroku-22/setup.sh
@@ -216,6 +216,7 @@ apt-get install -y --no-install-recommends \
     openssh-client \
     openssh-server \
     patch \
+    poppler-utils \
     postgresql-client-15 \
     python-is-python3 \
     python3 \


### PR DESCRIPTION
To address https://github.com/heroku/heroku-buildpack-ruby/issues/1200.

As the [ruby-vips](https://github.com/libvips/ruby-vips) Gem uses FFI, we don't need the headers (which are a chunky ~60 MB on top) in the builder images.

Because this pulls in `libpoppler` and dependencies, we can add `poppler-utils` with very minimal additional size impact. The `poppler-data` package with fonts etc was already on all stack images. As a result, https://github.com/heroku/heroku-buildpack-activestorage-preview can be simplified dramatically as it no longer has to do any Apt trickery to install Poppler.

```
heroku/heroku:18.v98         532MB
heroku/heroku:18             552MB
heroku/heroku:18-build.v98   1.21GB
heroku/heroku:18-build       1.23GB

heroku/heroku:20.v98         610MB
heroku/heroku:20             634MB
heroku/heroku:20-build.v98   1.45GB
heroku/heroku:20-build       1.48GB

heroku/heroku:22.v98         634MB
heroku/heroku:22             653MB
heroku/heroku:22-build.v98   1.01GB
heroku/heroku:22-build       1.03GB
```

GUS-W-9927197
GUS-W-12613616