### PR TITLE
move gettext-base to runtime images

### DIFF
--- a/heroku-20/installed-packages.txt
+++ b/heroku-20/installed-packages.txt
@@ -42,6 +42,7 @@ gcc-10-base
 gcc-9
 gcc-9-base
 geoip-database
+gettext-base
 ghostscript
 gir1.2-glib-2.0
 gir1.2-harfbuzz-0.0

--- a/heroku-20/setup.sh
+++ b/heroku-20/setup.sh
@@ -123,6 +123,7 @@ apt-get install -y --no-install-recommends \
     fontconfig \
     gcc \
     geoip-database \
+    gettext-base \
     ghostscript \
     gir1.2-harfbuzz-0.0 \
     git \

--- a/heroku-22/installed-packages.txt
+++ b/heroku-22/installed-packages.txt
@@ -41,6 +41,7 @@ gcc-11
 gcc-11-base
 gcc-12-base
 geoip-database
+gettext-base
 ghostscript
 gir1.2-glib-2.0
 gir1.2-harfbuzz-0.0

--- a/heroku-22/setup.sh
+++ b/heroku-22/setup.sh
@@ -123,6 +123,7 @@ apt-get install -y --no-install-recommends \
     fontconfig \
     gcc \
     geoip-database \
+    gettext-base \
     ghostscript \
     gir1.2-harfbuzz-0.0 \
     git \


### PR DESCRIPTION
The [`gettext-base` Ubuntu package](https://packages.ubuntu.com/focal/gettext-base) contains the following programs:

- `gettext.sh`, containing translation utility functions (for use by shell scripts)
- `gettext`, to translate strings (for use by shell scripts or programs)
- `ngettext`, to translate pluralized strings dependent on a given number (for use by shell scripts or programs)
- `envsubst`, to substitute simple environment variable references inside a file (also useful for other purposes, e.g. for Nginx config file processing in the Nginx buildpack)

These utilities are the runtime complements to the utilities in the `gettext` package, which are used to extract, manage, and compile translation strings.

The `gettext` package is, correctly, in the build variants of the stack images, but `gettext-base` should be in the runtime portion.

Size impact is minimal:

```ShellSession
# apt-get install gettext-base
Reading package lists... Done
Building dependency tree... Done
Reading state information... Done
The following NEW packages will be installed:
  gettext-base
0 upgraded, 1 newly installed, 0 to remove and 96 not upgraded.
Need to get 37.8 kB of archives.
After this operation, 291 kB of additional disk space will be used.
Get:1 http://archive.ubuntu.com/ubuntu jammy/main amd64 gettext-base amd64 0.21-4ubuntu4 [37.8 kB]
Fetched 37.8 kB in 0s (128 kB/s)       
…
```

GUS-W-13608406