### PR TITLE
Use base image terminology

### DIFF
--- a/BUILD.md
+++ b/BUILD.md
@@ -50,7 +50,7 @@ We use GitHub Actions to build and release Heroku Base Images:
 
 # Releasing Heroku Base Images Locally (Prime)
 
-When building Heroku Base Images for release locally, youll need a number of additional steps.
+When building Heroku Base Images for release locally, you'll need a number of additional steps.
 
 NOTE: These steps do *not* apply to `*cnb*` images.
 

--- a/BUILD.md
+++ b/BUILD.md
@@ -1,11 +1,11 @@
-# Building Stack Images Locally
+# Building Heroku Base Images Locally
 
 ## Prepare your local environment
 
 The build scripts in this repository require bash 4+. To update to newer bash on OS X, see:
 https://johndjameson.com/blog/updating-your-shell-with-homebrew/
 
-## Adding packages to the stack image
+## Adding packages to the base image
 
 Add the package you want to the appropriate `setup.sh` for example `heroku-22/setup.sh`:
 
@@ -21,7 +21,7 @@ The `*cnb*` variants inherit the installed packages from the non-`*cnb*` variant
 
 ## Build
 
-To build the stack images locally, run this from the repo root:
+To build the base images locally, run this from the repo root:
 
     bin/build.sh STACK_VERSION
 
@@ -36,31 +36,29 @@ If you're building on a machine with an architecture other than amd64, set `DOCK
 The supported stacks are: `20` and `22`. This script will build a family
 of 4 images:
 
-* `heroku/heroku:{STACK_VERSION}` - The runtime stack image for the Heroku platform
-* `heroku/heroku:{STACK_VERSION}-build` - The build-time stack image for the Heroku platform
-* `heroku/heroku:{STACK_VERSION}-cnb` - The runtime stack image for Cloud Native Buildpacks
-* `heroku/heroku:{STACK_VERSION}-cnb-build` - The build-time stack image for Cloud Native Buildpacks
+* `heroku/heroku:{STACK_VERSION}` - The runtime base image for the Heroku platform
+* `heroku/heroku:{STACK_VERSION}-build` - The build-time base image for the Heroku platform
+* `heroku/heroku:{STACK_VERSION}-cnb` - The runtime base image for Cloud Native Buildpacks
+* `heroku/heroku:{STACK_VERSION}-cnb-build` - The build-time base image for Cloud Native Buildpacks
 
-# Releasing Stack Images
+# Releasing Heroku Base Images
 
-We use GitHub Actions to build and release Stack Images:
+We use GitHub Actions to build and release Heroku Base Images:
 
 * Any push to `main` will build the images and push the nightly Docker tag variants (such as `heroku/heroku:22-build.nightly`).
 * Any new Git tag will build the image and push the latest Docker tag (such as `heroku/heroku:22-build`), as well as a versioned tag (such as `heroku/heroku:22-build.v89`).
 
-# Releasing Heroku Stack Images Locally (Prime)
+# Releasing Heroku Base Images Locally (Prime)
 
-When building Heroku Stack Images for release locally, youll need a number of additional steps.
+When building Heroku Base Images for release locally, youll need a number of additional steps.
 
 NOTE: These steps do *not* apply to `*cnb*` images.
 
     export DOCKER_DEFAULT_PLATFORM=linux/amd64
-    # Build the stack image(s) as you would above
+    # Build the base image(s) as you would above
     # …
-    cd stack-images/tools
-    # build the stack-image-tooling
-    docker build . -t heroku/stack-image-tools
+    docker build ./tools -t heroku/image-tools
     # SET MANIFEST_APP_URL and MANIFEST_APP_TOKEN values, this is the app that controls the bucket for images and metadata about the images (Cheverny)
-    docker run -it --rm --privileged -v /var/run/docker.sock:/var/run/docker.sock -e "MANIFEST_APP_URL=$MANIFEST_APP_URL" -e "MANIFEST_APP_TOKEN=$MANIFEST_APP_TOKEN" heroku/stack-image-tools STACK
-    # this will use your local docker image and convert it to a heroku stack image
+    docker run -it --rm --privileged -v /var/run/docker.sock:/var/run/docker.sock -e "MANIFEST_APP_URL=$MANIFEST_APP_URL" -e "MANIFEST_APP_TOKEN=$MANIFEST_APP_TOKEN" heroku/image-tools STACK
+    # this will use your local docker image and convert it to a heroku base image
     # it will then upload this image and the staging manifest via the MANIFEST_APP

--- a/BUILD.md
+++ b/BUILD.md
@@ -36,10 +36,10 @@ If you're building on a machine with an architecture other than amd64, set `DOCK
 The supported stacks are: `20` and `22`. This script will build a family
 of 4 images:
 
-* `heroku/heroku:{STACK_VERSION}` - The runtime base image for the Heroku platform
-* `heroku/heroku:{STACK_VERSION}-build` - The build-time base image for the Heroku platform
-* `heroku/heroku:{STACK_VERSION}-cnb` - The runtime base image for Cloud Native Buildpacks
-* `heroku/heroku:{STACK_VERSION}-cnb-build` - The build-time base image for Cloud Native Buildpacks
+* `heroku/heroku:{STACK_VERSION}` - The base run image for the Heroku platform
+* `heroku/heroku:{STACK_VERSION}-build` - The base build image for the Heroku platform
+* `heroku/heroku:{STACK_VERSION}-cnb` - The base run image for Cloud Native Buildpacks
+* `heroku/heroku:{STACK_VERSION}-cnb-build` - The base build image for Cloud Native Buildpacks
 
 # Releasing Heroku Base Images
 

--- a/README.md
+++ b/README.md
@@ -1,28 +1,28 @@
-## Heroku Stack Images
+## Heroku Base Images
 
-[![CI](https://github.com/heroku/stack-images/actions/workflows/ci.yml/badge.svg)](https://github.com/heroku/stack-images/actions/workflows/ci.yml)
+[![CI](https://github.com/heroku/base-images/actions/workflows/ci.yml/badge.svg)](https://github.com/heroku/base-images/actions/workflows/ci.yml)
 
-This repository holds recipes for building [Heroku stack images](https://devcenter.heroku.com/articles/stack).
+This repository holds recipes for building the base images for [Heroku stacks](https://devcenter.heroku.com/articles/stack).
 The recipes are also rendered into Docker images that are available on Docker Hub:
 
-| Image                                     | Base                                  | Type                       | Status      |
-|-------------------------------------------|---------------------------------------|----------------------------|-------------|
-| [heroku/heroku:18][heroku-tags]           | [ubuntu:18.04][ubuntu-tags]           | Heroku Runtime Stack Image | End-of-life |
-| [heroku/heroku:18-build][heroku-tags]     | [heroku/heroku:18][heroku-tags]       | Heroku Build Stack Image   | End-of-life |
-| [heroku/heroku:18-cnb][heroku-tags]       | [heroku/heroku:18][heroku-tags]       | CNB Runtime Stack Image    | End-of-life |
-| [heroku/heroku:18-cnb-build][heroku-tags] | [heroku/heroku:18-build][heroku-tags] | CNB Build Stack Image      | End-of-life |
-| [heroku/heroku:20][heroku-tags]           | [ubuntu:20.04][ubuntu-tags]           | Heroku Runtime Stack Image | Available   |
-| [heroku/heroku:20-build][heroku-tags]     | [heroku/heroku:20][heroku-tags]       | Heroku Build Stack Image   | Available   |
-| [heroku/heroku:20-cnb][heroku-tags]       | [heroku/heroku:20][heroku-tags]       | CNB Runtime Stack Image    | Available   |
-| [heroku/heroku:20-cnb-build][heroku-tags] | [heroku/heroku:20-build][heroku-tags] | CNB Build Stack Image      | Available   |
-| [heroku/heroku:22][heroku-tags]           | [ubuntu:22.04][ubuntu-tags]           | Heroku Runtime Stack Image | Recommended |
-| [heroku/heroku:22-build][heroku-tags]     | [heroku/heroku:22][heroku-tags]       | Heroku Build Stack Image   | Recommended |
-| [heroku/heroku:22-cnb][heroku-tags]       | [heroku/heroku:22][heroku-tags]       | CNB Runtime Stack Image    | Recommended |
-| [heroku/heroku:22-cnb-build][heroku-tags] | [heroku/heroku:22-build][heroku-tags] | CNB Build Stack Image      | Recommended |
+| Image                                     | Base                                  | Type                      | Status      |
+|-------------------------------------------|---------------------------------------|---------------------------|-------------|
+| [heroku/heroku:18][heroku-tags]           | [ubuntu:18.04][ubuntu-tags]           | Heroku Runtime Base Image | End-of-life |
+| [heroku/heroku:18-build][heroku-tags]     | [heroku/heroku:18][heroku-tags]       | Heroku Build Base Image   | End-of-life |
+| [heroku/heroku:18-cnb][heroku-tags]       | [heroku/heroku:18][heroku-tags]       | CNB Runtime Base Image    | End-of-life |
+| [heroku/heroku:18-cnb-build][heroku-tags] | [heroku/heroku:18-build][heroku-tags] | CNB Build Base Image      | End-of-life |
+| [heroku/heroku:20][heroku-tags]           | [ubuntu:20.04][ubuntu-tags]           | Heroku Runtime Base Image | Available   |
+| [heroku/heroku:20-build][heroku-tags]     | [heroku/heroku:20][heroku-tags]       | Heroku Build Base Image   | Available   |
+| [heroku/heroku:20-cnb][heroku-tags]       | [heroku/heroku:20][heroku-tags]       | CNB Runtime Base Image    | Available   |
+| [heroku/heroku:20-cnb-build][heroku-tags] | [heroku/heroku:20-build][heroku-tags] | CNB Build Base Image      | Available   |
+| [heroku/heroku:22][heroku-tags]           | [ubuntu:22.04][ubuntu-tags]           | Heroku Runtime Base Image | Recommended |
+| [heroku/heroku:22-build][heroku-tags]     | [heroku/heroku:22][heroku-tags]       | Heroku Build Base Image   | Recommended |
+| [heroku/heroku:22-cnb][heroku-tags]       | [heroku/heroku:22][heroku-tags]       | CNB Runtime Base Image    | Recommended |
+| [heroku/heroku:22-cnb-build][heroku-tags] | [heroku/heroku:22-build][heroku-tags] | CNB Build Base Image      | Recommended |
 
 ### Learn more
 
-* [Lists of packages installed on current stacks](https://devcenter.heroku.com/articles/stack-packages)
+* [Lists of packages installed on current Heroku stacks](https://devcenter.heroku.com/articles/stack-packages)
 * [Stack update policy](https://devcenter.heroku.com/articles/stack-update-policy)
 
 See [BUILD.md](BUILD.md) for instructions on how to build the images yourself.

--- a/README.md
+++ b/README.md
@@ -5,20 +5,20 @@
 This repository holds recipes for building the base images for [Heroku stacks](https://devcenter.heroku.com/articles/stack).
 The recipes are also rendered into Docker images that are available on Docker Hub:
 
-| Image                                     | Base                                  | Type                      | Status      |
-|-------------------------------------------|---------------------------------------|---------------------------|-------------|
-| [heroku/heroku:18][heroku-tags]           | [ubuntu:18.04][ubuntu-tags]           | Heroku Base Run Image     | End-of-life |
-| [heroku/heroku:18-build][heroku-tags]     | [heroku/heroku:18][heroku-tags]       | Heroku Base Build Image   | End-of-life |
-| [heroku/heroku:18-cnb][heroku-tags]       | [heroku/heroku:18][heroku-tags]       | CNB Base Run Image        | End-of-life |
-| [heroku/heroku:18-cnb-build][heroku-tags] | [heroku/heroku:18-build][heroku-tags] | CNB Base Build Image      | End-of-life |
-| [heroku/heroku:20][heroku-tags]           | [ubuntu:20.04][ubuntu-tags]           | Heroku Base Run Image     | Available   |
-| [heroku/heroku:20-build][heroku-tags]     | [heroku/heroku:20][heroku-tags]       | Heroku Base Build Image   | Available   |
-| [heroku/heroku:20-cnb][heroku-tags]       | [heroku/heroku:20][heroku-tags]       | CNB Base Run Image        | Available   |
-| [heroku/heroku:20-cnb-build][heroku-tags] | [heroku/heroku:20-build][heroku-tags] | CNB Base Build Image      | Available   |
-| [heroku/heroku:22][heroku-tags]           | [ubuntu:22.04][ubuntu-tags]           | Heroku Base Run Image     | Recommended |
-| [heroku/heroku:22-build][heroku-tags]     | [heroku/heroku:22][heroku-tags]       | Heroku Base Build Image   | Recommended |
-| [heroku/heroku:22-cnb][heroku-tags]       | [heroku/heroku:22][heroku-tags]       | CNB Base Run Image        | Recommended |
-| [heroku/heroku:22-cnb-build][heroku-tags] | [heroku/heroku:22-build][heroku-tags] | CNB Base Build Image      | Recommended |
+| Image                                     | Base                                  | Type                    | Status      |
+|-------------------------------------------|---------------------------------------|-------------------------|-------------|
+| [heroku/heroku:18][heroku-tags]           | [ubuntu:18.04][ubuntu-tags]           | Heroku Base Run Image   | End-of-life |
+| [heroku/heroku:18-build][heroku-tags]     | [heroku/heroku:18][heroku-tags]       | Heroku Base Build Image | End-of-life |
+| [heroku/heroku:18-cnb][heroku-tags]       | [heroku/heroku:18][heroku-tags]       | CNB Base Run Image      | End-of-life |
+| [heroku/heroku:18-cnb-build][heroku-tags] | [heroku/heroku:18-build][heroku-tags] | CNB Base Build Image    | End-of-life |
+| [heroku/heroku:20][heroku-tags]           | [ubuntu:20.04][ubuntu-tags]           | Heroku Base Run Image   | Available   |
+| [heroku/heroku:20-build][heroku-tags]     | [heroku/heroku:20][heroku-tags]       | Heroku Base Build Image | Available   |
+| [heroku/heroku:20-cnb][heroku-tags]       | [heroku/heroku:20][heroku-tags]       | CNB Base Run Image      | Available   |
+| [heroku/heroku:20-cnb-build][heroku-tags] | [heroku/heroku:20-build][heroku-tags] | CNB Base Build Image    | Available   |
+| [heroku/heroku:22][heroku-tags]           | [ubuntu:22.04][ubuntu-tags]           | Heroku Base Run Image   | Recommended |
+| [heroku/heroku:22-build][heroku-tags]     | [heroku/heroku:22][heroku-tags]       | Heroku Base Build Image | Recommended |
+| [heroku/heroku:22-cnb][heroku-tags]       | [heroku/heroku:22][heroku-tags]       | CNB Base Run Image      | Recommended |
+| [heroku/heroku:22-cnb-build][heroku-tags] | [heroku/heroku:22-build][heroku-tags] | CNB Base Build Image    | Recommended |
 
 ### Learn more
 

--- a/README.md
+++ b/README.md
@@ -7,18 +7,18 @@ The recipes are also rendered into Docker images that are available on Docker Hu
 
 | Image                                     | Base                                  | Type                      | Status      |
 |-------------------------------------------|---------------------------------------|---------------------------|-------------|
-| [heroku/heroku:18][heroku-tags]           | [ubuntu:18.04][ubuntu-tags]           | Heroku Runtime Base Image | End-of-life |
-| [heroku/heroku:18-build][heroku-tags]     | [heroku/heroku:18][heroku-tags]       | Heroku Build Base Image   | End-of-life |
-| [heroku/heroku:18-cnb][heroku-tags]       | [heroku/heroku:18][heroku-tags]       | CNB Runtime Base Image    | End-of-life |
-| [heroku/heroku:18-cnb-build][heroku-tags] | [heroku/heroku:18-build][heroku-tags] | CNB Build Base Image      | End-of-life |
-| [heroku/heroku:20][heroku-tags]           | [ubuntu:20.04][ubuntu-tags]           | Heroku Runtime Base Image | Available   |
-| [heroku/heroku:20-build][heroku-tags]     | [heroku/heroku:20][heroku-tags]       | Heroku Build Base Image   | Available   |
-| [heroku/heroku:20-cnb][heroku-tags]       | [heroku/heroku:20][heroku-tags]       | CNB Runtime Base Image    | Available   |
-| [heroku/heroku:20-cnb-build][heroku-tags] | [heroku/heroku:20-build][heroku-tags] | CNB Build Base Image      | Available   |
-| [heroku/heroku:22][heroku-tags]           | [ubuntu:22.04][ubuntu-tags]           | Heroku Runtime Base Image | Recommended |
-| [heroku/heroku:22-build][heroku-tags]     | [heroku/heroku:22][heroku-tags]       | Heroku Build Base Image   | Recommended |
-| [heroku/heroku:22-cnb][heroku-tags]       | [heroku/heroku:22][heroku-tags]       | CNB Runtime Base Image    | Recommended |
-| [heroku/heroku:22-cnb-build][heroku-tags] | [heroku/heroku:22-build][heroku-tags] | CNB Build Base Image      | Recommended |
+| [heroku/heroku:18][heroku-tags]           | [ubuntu:18.04][ubuntu-tags]           | Heroku Base Run Image     | End-of-life |
+| [heroku/heroku:18-build][heroku-tags]     | [heroku/heroku:18][heroku-tags]       | Heroku Base Build Image   | End-of-life |
+| [heroku/heroku:18-cnb][heroku-tags]       | [heroku/heroku:18][heroku-tags]       | CNB Base Run Image        | End-of-life |
+| [heroku/heroku:18-cnb-build][heroku-tags] | [heroku/heroku:18-build][heroku-tags] | CNB Base Build Image      | End-of-life |
+| [heroku/heroku:20][heroku-tags]           | [ubuntu:20.04][ubuntu-tags]           | Heroku Base Run Image     | Available   |
+| [heroku/heroku:20-build][heroku-tags]     | [heroku/heroku:20][heroku-tags]       | Heroku Base Build Image   | Available   |
+| [heroku/heroku:20-cnb][heroku-tags]       | [heroku/heroku:20][heroku-tags]       | CNB Base Run Image        | Available   |
+| [heroku/heroku:20-cnb-build][heroku-tags] | [heroku/heroku:20-build][heroku-tags] | CNB Base Build Image      | Available   |
+| [heroku/heroku:22][heroku-tags]           | [ubuntu:22.04][ubuntu-tags]           | Heroku Base Run Image     | Recommended |
+| [heroku/heroku:22-build][heroku-tags]     | [heroku/heroku:22][heroku-tags]       | Heroku Base Build Image   | Recommended |
+| [heroku/heroku:22-cnb][heroku-tags]       | [heroku/heroku:22][heroku-tags]       | CNB Base Run Image        | Recommended |
+| [heroku/heroku:22-cnb-build][heroku-tags] | [heroku/heroku:22-build][heroku-tags] | CNB Base Build Image      | Recommended |
 
 ### Learn more
 

--- a/bin/build.sh
+++ b/bin/build.sh
@@ -19,16 +19,16 @@ write_package_list() {
 RUN_IMAGE_TAG="heroku/heroku:${STACK_VERSION}"
 RUN_DOCKERFILE_DIR="heroku-${STACK_VERSION}"
 [[ -d "${RUN_DOCKERFILE_DIR}" ]] || abort "fatal: directory ${RUN_DOCKERFILE_DIR} not found"
-display "Building ${RUN_DOCKERFILE_DIR} / ${RUN_IMAGE_TAG} Heroku runtime image"
+display "Building ${RUN_DOCKERFILE_DIR} / ${RUN_IMAGE_TAG} Heroku run image"
 docker build --pull --tag "${RUN_IMAGE_TAG}" "${RUN_DOCKERFILE_DIR}" | indent
 write_package_list "${RUN_IMAGE_TAG}" "${RUN_DOCKERFILE_DIR}"
 
 # The --pull option is not used for variants to ensure they are based on the
-# runtime stack image built above, rather than the one last published to DockerHub.
+# run image built above, rather than the one last published to Docker Hub.
 
 BUILD_IMAGE_TAG="${RUN_IMAGE_TAG}-build"
 BUILD_DOCKERFILE_DIR="${RUN_DOCKERFILE_DIR}-build"
-display "Building ${BUILD_DOCKERFILE_DIR} / ${BUILD_IMAGE_TAG} Heroku build-time image"
+display "Building ${BUILD_DOCKERFILE_DIR} / ${BUILD_IMAGE_TAG} Heroku build image"
 docker build --tag "$BUILD_IMAGE_TAG" "$BUILD_DOCKERFILE_DIR" | indent
 write_package_list "$BUILD_IMAGE_TAG" "$BUILD_DOCKERFILE_DIR"
 
@@ -37,12 +37,12 @@ write_package_list "$BUILD_IMAGE_TAG" "$BUILD_DOCKERFILE_DIR"
 
 CNB_RUN_IMAGE_TAG="${RUN_IMAGE_TAG}-cnb"
 CNB_RUN_DOCKERFILE_DIR="${RUN_DOCKERFILE_DIR}-cnb"
-display "Building ${CNB_RUN_DOCKERFILE_DIR} / ${CNB_RUN_IMAGE_TAG} CNB runtime image"
+display "Building ${CNB_RUN_DOCKERFILE_DIR} / ${CNB_RUN_IMAGE_TAG} CNB run image"
 docker build --tag "$CNB_RUN_IMAGE_TAG" "$CNB_RUN_DOCKERFILE_DIR" | indent
 
 CNB_BUILD_IMAGE_TAG="${RUN_IMAGE_TAG}-cnb-build"
 CNB_BUILD_DOCKERFILE_DIR="${RUN_DOCKERFILE_DIR}-cnb-build"
-display "Building ${CNB_BUILD_DOCKERFILE_DIR} / ${CNB_BUILD_IMAGE_TAG} CNB build-time image"
+display "Building ${CNB_BUILD_DOCKERFILE_DIR} / ${CNB_BUILD_IMAGE_TAG} CNB build image"
 docker build --tag "$CNB_BUILD_IMAGE_TAG" "$CNB_BUILD_DOCKERFILE_DIR" | indent
 
 display "Size breakdown..."

--- a/heroku-20/setup.sh
+++ b/heroku-20/setup.sh
@@ -255,7 +255,7 @@ IMAGEMAGICK_POLICY
 # Temporarily install ca-certificates-java to generate the certificates store used
 # by Java apps. Generation occurs in a post-install script which requires a JRE.
 # We're using OpenJDK 8 rather than something newer, to work around:
-# https://github.com/heroku/stack-images/pull/103#issuecomment-389544431
+# https://github.com/heroku/base-images/pull/103#issuecomment-389544431
 apt-get install -y --no-install-recommends ca-certificates-java openjdk-8-jre-headless
 # Using remove rather than purge so that the generated certs are left behind.
 apt-get remove -y ca-certificates-java

--- a/heroku-22/setup.sh
+++ b/heroku-22/setup.sh
@@ -257,7 +257,7 @@ IMAGEMAGICK_POLICY
 # Temporarily install ca-certificates-java to generate the certificates store used
 # by Java apps. Generation occurs in a post-install script which requires a JRE.
 # We're using OpenJDK 8 rather than something newer, to work around:
-# https://github.com/heroku/stack-images/pull/103#issuecomment-389544431
+# https://github.com/heroku/base-images/pull/103#issuecomment-389544431
 apt-get install -y --no-install-recommends ca-certificates-java openjdk-8-jre-headless
 # Using remove rather than purge so that the generated certs are left behind.
 apt-get remove -y ca-certificates-java

--- a/tools/bin/publish-manifests
+++ b/tools/bin/publish-manifests
@@ -11,7 +11,7 @@ if ls /tmp/*64-*.manifest >& /dev/null; then
         }) | {stacks: .}' \
         /tmp/*64-*.manifest |
         curl \
-            --fail --user-agent 'Stack Image Tools' \
+            --fail --user-agent 'Base Image Tools' \
             --header "Authorization: Bearer $MANIFEST_APP_TOKEN" \
             --header "Content-Type: application/json" \
             --request PATCH \

--- a/tools/bin/upload-image
+++ b/tools/bin/upload-image
@@ -28,7 +28,7 @@ jq \
     }' |
     curl \
         --silent --show-error --fail \
-        --user-agent 'Stack Image Tools' \
+        --user-agent 'Base Image Tools' \
         --header "Authorization: Bearer $MANIFEST_APP_TOKEN" \
         --header "Content-Type: application/json" \
         --data @- \
@@ -43,7 +43,7 @@ display "Uploading Image to S3"
 PUT_URL=$(jq -r .put_url "$IMG_MANIFEST")
 curl \
     --silent --show-error \
-    --user-agent 'Stack Image Tools' \
+    --user-agent 'Base Image Tools' \
     --header "Content-Type: application/octet-stream" \
     --upload-file "$IMG_GZ" \
     "$PUT_URL"


### PR DESCRIPTION
This is part of the [Rename stack image to base image](https://gus.lightning.force.com/lightning/r/ADM_Epic__c/a3QEE000000jgBB2AY/view) epic.
> The Heroku term "stack" is overloaded. To reduce confusion, we will rename "stack image" to "base image".

[W-14646087](https://gus.lightning.force.com/lightning/r/a07EE00001gIq7iYAC/view)

> [!Note]
> This repository will also be renamed to `heroku/base-images` after this PR is approved/merged.
