### PR TITLE
Add python3-tomli to 22-build

### DIFF
--- a/heroku-22-build/installed-packages-amd64.txt
+++ b/heroku-22-build/installed-packages-amd64.txt
@@ -581,6 +581,7 @@ python3-lib2to3
 python3-minimal
 python3-patiencediff
 python3-six
+python3-tomli
 python3-urllib3
 python3.10
 python3.10-dev

--- a/heroku-22-build/setup.sh
+++ b/heroku-22-build/setup.sh
@@ -79,6 +79,7 @@ packages=(
   mercurial
   patchelf
   python3-dev
+  python3-tomli
   zlib1g-dev
 )
 


### PR DESCRIPTION
Ubuntu 22.04 ships with Python 3.10; Ubuntu 24.04 with Python 3.12. The [tomllib package was added to Python 3.11](https://peps.python.org/pep-0680/). It is [based on tomli](https://peps.python.org/pep-0680/#reference-implementation), which is available in Ubuntu as the [python3-tomli](https://packages.ubuntu.com/jammy/python3-tomli) package in an acceptable version.

A [conditional aliased import allows them to be used interchangeably](https://github.com/hukkin/tomli?tab=readme-ov-file#building-a-tomlitomllib-compatibility-layer), meaning we can parse TOML using Python scripting during builds on all stacks. This helps achieve better parity between Classic and CNB buildpacks by e.g. allowing Classic buildpacks to parse files such as `project.toml`.

The only meaningful difference since version 1.2.2 (the one available in Ubuntu 22.04) regards datetime parsing:

> Backport: Allow lower case "t" and "z" in datetimes

This change was [added in tomllib 1.2.3](https://github.com/hukkin/tomli/blob/master/CHANGELOG.md#123) and is [included in the bundled Python version](https://github.com/python/cpython/pull/31498/files#diff-7a6e50655a366b407bf507597e1db88d9669008c860b8800b4f75c940ecdf777R43-R45), but we consider this difference negligible.

GUS-W-19578105