### PR TITLE
Add `libtheoradec2` and `libtheoraenc2` to Heroku-26 run image

### DIFF
--- a/heroku-26-build/installed-packages-amd64.txt
+++ b/heroku-26-build/installed-packages-amd64.txt
@@ -422,6 +422,8 @@ libtext-wrapi18n-perl
 libthai-data
 libthai0
 libtheora1
+libtheoradec2
+libtheoraenc2
 libtiff-dev
 libtiff6
 libtiffxx6

--- a/heroku-26-build/installed-packages-arm64.txt
+++ b/heroku-26-build/installed-packages-arm64.txt
@@ -420,6 +420,8 @@ libtext-wrapi18n-perl
 libthai-data
 libthai0
 libtheora1
+libtheoradec2
+libtheoraenc2
 libtiff-dev
 libtiff6
 libtiffxx6

--- a/heroku-26/installed-packages-amd64.txt
+++ b/heroku-26/installed-packages-amd64.txt
@@ -276,6 +276,8 @@ libtext-wrapi18n-perl
 libthai-data
 libthai0
 libtheora1
+libtheoradec2
+libtheoraenc2
 libtiff6
 libtinfo6
 libtirpc-common

--- a/heroku-26/installed-packages-arm64.txt
+++ b/heroku-26/installed-packages-arm64.txt
@@ -276,6 +276,8 @@ libtext-wrapi18n-perl
 libthai-data
 libthai0
 libtheora1
+libtheoradec2
+libtheoraenc2
 libtiff6
 libtinfo6
 libtirpc-common

--- a/heroku-26/setup.sh
+++ b/heroku-26/setup.sh
@@ -92,6 +92,8 @@ packages=(
   libspeex1 # Used by FFmpeg in heroku-buildpack-activestorage-preview.
   libsvtav1enc2 # Used by FFmpeg in heroku-buildpack-activestorage-preview.
   libtheora1 # Used by FFmpeg in heroku-buildpack-activestorage-preview.
+  libtheoradec2 # Used by FFmpeg in heroku-buildpack-activestorage-preview.
+  libtheoraenc2 # Used by FFmpeg in heroku-buildpack-activestorage-preview.
   libuv1t64
   libvips42 # Used by the ruby-vips gem / Rails Active Storage Previews.
   libvorbisenc2 # Used by FFmpeg in heroku-buildpack-activestorage-preview.


### PR DESCRIPTION
Since in older Ubuntu versions the `libtheora0` package used to contain these too:
https://packages.ubuntu.com/noble/amd64/libtheora0/filelist

However, in Ubuntu 26.04 they are no longer in `libtheora1`:
https://packages.ubuntu.com/resolute/amd64/libtheora1/filelist

And instead in separate packages, as seen by `libtheora-dev`'s dependency tree:
https://packages.ubuntu.com/resolute/libtheora-dev

We need both of these libraries at run-time for FFmpeg in:
https://github.com/heroku/heroku-buildpack-activestorage-preview/pull/77

GUS-W-22025050.