### PR TITLE
Add `libcrypt-dev` to the Heroku-26 build image

### DIFF
--- a/heroku-26-build/installed-packages-amd64.txt
+++ b/heroku-26-build/installed-packages-amd64.txt
@@ -133,6 +133,7 @@ libcc1-0
 libcfitsio10t64
 libcgif0
 libcom-err2
+libcrypt-dev
 libcrypt1
 libctf-nobfd0
 libctf0

--- a/heroku-26-build/installed-packages-arm64.txt
+++ b/heroku-26-build/installed-packages-arm64.txt
@@ -133,6 +133,7 @@ libcc1-0
 libcfitsio10t64
 libcgif0
 libcom-err2
+libcrypt-dev
 libcrypt1
 libctf-nobfd0
 libctf0

--- a/heroku-26-build/setup.sh
+++ b/heroku-26-build/setup.sh
@@ -16,6 +16,7 @@ packages=(
   libbsd-dev
   libbz2-dev
   libcairo2-dev
+  libcrypt-dev
   libcurl4-openssl-dev
   libev-dev
   libevent-dev


### PR DESCRIPTION
Since it used to be a transitive dependency of other packages in Heroku-24 and older, but is no longer in Ubuntu 26.04.

It's used by the PHP buildpack when compiling Apache, and whilst we could instead install the headers in just the PHP build environment (given that the library is still present in the run image), the headers are only 380 KB and might be used by other use-cases.

Fixes this APT-util linking error during compilation of Apache:

```
/usr/bin/aarch64-linux-gnu-ld.bfd: /tmp/.../httpd-2.4.66/srclib/apr-util/.libs/libaprutil-1.so: undefined reference to `crypt'
collect2: error: ld returned 1 exit status
make[2]: *** [Makefile:90: httxt2dbm] Error 1
make[2]: *** Waiting for unfinished jobs....
/usr/bin/aarch64-linux-gnu-ld.bfd: /tmp/.../httpd-2.4.66/srclib/apr-util/.libs/libaprutil-1.so: undefined reference to `crypt'
collect2: error: ld returned 1 exit status
make[2]: *** [Makefile:52: htdigest] Error 1
/usr/bin/aarch64-linux-gnu-ld.bfd: passwd_common.o: in function `mkhash':
/tmp/.../httpd-2.4.66/support/passwd_common.c:233:(.text+0x670): undefined reference to `crypt'
/usr/bin/aarch64-linux-gnu-ld.bfd: /tmp/.../httpd-2.4.66/support/passwd_common.c:245:(.text+0x6bc): undefined reference to `crypt'
/usr/bin/aarch64-linux-gnu-ld.bfd: passwd_common.o: in function `mkhash':
/tmp/.../httpd-2.4.66/support/passwd_common.c:233:(.text+0x670): undefined reference to `crypt'
/usr/bin/aarch64-linux-gnu-ld.bfd: /tmp/.../httpd-2.4.66/support/passwd_common.c:245:(.text+0x6bc): undefined reference to `crypt'
collect2: error: ld returned 1 exit status
collect2: error: ld returned 1 exit status
make[2]: *** [Makefile:65: htdbm] Error 1
make[2]: *** [Makefile:48: htpasswd] Error 1
make[1]: *** [/tmp/.../httpd-2.4.66/build/rules.mk:75: all-recursive] Error 1
```

https://github.com/heroku/heroku-buildpack-php/actions/runs/24458100449/job/71464572510#step:5:1318

GUS-W-22047202.