### PR TITLE
Update postgresql-client to v18

### DIFF
--- a/heroku-22-build/installed-packages-amd64.txt
+++ b/heroku-22-build/installed-packages-amd64.txt
@@ -565,7 +565,7 @@ pinentry-curses
 pkg-config
 poppler-data
 poppler-utils
-postgresql-client-17
+postgresql-client-18
 postgresql-client-common
 procps
 python-is-python3

--- a/heroku-22/installed-packages-amd64.txt
+++ b/heroku-22/installed-packages-amd64.txt
@@ -371,7 +371,7 @@ perl-modules-5.34
 pinentry-curses
 poppler-data
 poppler-utils
-postgresql-client-17
+postgresql-client-18
 postgresql-client-common
 procps
 python-is-python3

--- a/heroku-22/setup.sh
+++ b/heroku-22/setup.sh
@@ -145,7 +145,7 @@ packages=(
   openssh-server
   patch
   poppler-utils
-  postgresql-client-17
+  postgresql-client-18
   python-is-python3
   python3
   rename

--- a/heroku-24-build/installed-packages-amd64.txt
+++ b/heroku-24-build/installed-packages-amd64.txt
@@ -231,7 +231,6 @@ libhashkit2t64
 libhdf5-103-1t64
 libheif-dev
 libheif-plugin-aomdec
-libheif-plugin-libde265
 libheif1
 libhogweed6t64
 libhwasan0
@@ -521,7 +520,7 @@ pkgconf
 pkgconf-bin
 poppler-data
 poppler-utils
-postgresql-client-17
+postgresql-client-18
 postgresql-client-common
 procps
 python3

--- a/heroku-24-build/installed-packages-amd64.txt
+++ b/heroku-24-build/installed-packages-amd64.txt
@@ -231,6 +231,7 @@ libhashkit2t64
 libhdf5-103-1t64
 libheif-dev
 libheif-plugin-aomdec
+libheif-plugin-libde265
 libheif1
 libhogweed6t64
 libhwasan0

--- a/heroku-24-build/installed-packages-arm64.txt
+++ b/heroku-24-build/installed-packages-arm64.txt
@@ -224,6 +224,7 @@ libhashkit2t64
 libhdf5-103-1t64
 libheif-dev
 libheif-plugin-aomdec
+libheif-plugin-libde265
 libheif1
 libhogweed6t64
 libhwasan0

--- a/heroku-24-build/installed-packages-arm64.txt
+++ b/heroku-24-build/installed-packages-arm64.txt
@@ -224,7 +224,6 @@ libhashkit2t64
 libhdf5-103-1t64
 libheif-dev
 libheif-plugin-aomdec
-libheif-plugin-libde265
 libheif1
 libhogweed6t64
 libhwasan0
@@ -513,7 +512,7 @@ pkgconf
 pkgconf-bin
 poppler-data
 poppler-utils
-postgresql-client-17
+postgresql-client-18
 postgresql-client-common
 procps
 python3

--- a/heroku-24/installed-packages-amd64.txt
+++ b/heroku-24/installed-packages-amd64.txt
@@ -101,7 +101,6 @@ libdatrie1
 libdav1d7
 libdb5.3t64
 libdbus-1-3
-libde265-0
 libdebconfclient0
 libdeflate0
 libdjvulibre-text
@@ -149,7 +148,6 @@ libharfbuzz0b
 libhashkit2t64
 libhdf5-103-1t64
 libheif-plugin-aomdec
-libheif-plugin-libde265
 libheif1
 libhogweed6t64
 libhwy1t64
@@ -334,7 +332,7 @@ perl-modules-5.38
 pinentry-curses
 poppler-data
 poppler-utils
-postgresql-client-17
+postgresql-client-18
 postgresql-client-common
 procps
 readline-common

--- a/heroku-24/installed-packages-amd64.txt
+++ b/heroku-24/installed-packages-amd64.txt
@@ -101,6 +101,7 @@ libdatrie1
 libdav1d7
 libdb5.3t64
 libdbus-1-3
+libde265-0
 libdebconfclient0
 libdeflate0
 libdjvulibre-text
@@ -148,6 +149,7 @@ libharfbuzz0b
 libhashkit2t64
 libhdf5-103-1t64
 libheif-plugin-aomdec
+libheif-plugin-libde265
 libheif1
 libhogweed6t64
 libhwy1t64

--- a/heroku-24/installed-packages-arm64.txt
+++ b/heroku-24/installed-packages-arm64.txt
@@ -101,7 +101,6 @@ libdatrie1
 libdav1d7
 libdb5.3t64
 libdbus-1-3
-libde265-0
 libdebconfclient0
 libdeflate0
 libdjvulibre-text
@@ -149,7 +148,6 @@ libharfbuzz0b
 libhashkit2t64
 libhdf5-103-1t64
 libheif-plugin-aomdec
-libheif-plugin-libde265
 libheif1
 libhogweed6t64
 libhwy1t64
@@ -334,7 +332,7 @@ perl-modules-5.38
 pinentry-curses
 poppler-data
 poppler-utils
-postgresql-client-17
+postgresql-client-18
 postgresql-client-common
 procps
 readline-common

--- a/heroku-24/installed-packages-arm64.txt
+++ b/heroku-24/installed-packages-arm64.txt
@@ -101,6 +101,7 @@ libdatrie1
 libdav1d7
 libdb5.3t64
 libdbus-1-3
+libde265-0
 libdebconfclient0
 libdeflate0
 libdjvulibre-text
@@ -148,6 +149,7 @@ libharfbuzz0b
 libhashkit2t64
 libhdf5-103-1t64
 libheif-plugin-aomdec
+libheif-plugin-libde265
 libheif1
 libhogweed6t64
 libhwy1t64

--- a/heroku-24/setup.sh
+++ b/heroku-24/setup.sh
@@ -114,7 +114,7 @@ packages=(
   openssh-server # Used by Heroku Exec.
   patch
   poppler-utils # For Rails Active Storage Previews PDF support.
-  postgresql-client-17 # We need `psql` (and not just libpq) for Shield DB workflows (where connections are only possible from the dyno).
+  postgresql-client-18 # We need `psql` (and not just libpq) for Shield DB workflows (where connections are only possible from the dyno).
   rsync
   socat
   tar

--- a/heroku-26-build/installed-packages-amd64.txt
+++ b/heroku-26-build/installed-packages-amd64.txt
@@ -531,7 +531,7 @@ pkgconf
 pkgconf-bin
 poppler-data
 poppler-utils
-postgresql-client-17
+postgresql-client-18
 postgresql-client-common
 procps
 python3

--- a/heroku-26-build/installed-packages-arm64.txt
+++ b/heroku-26-build/installed-packages-arm64.txt
@@ -529,7 +529,7 @@ pkgconf
 pkgconf-bin
 poppler-data
 poppler-utils
-postgresql-client-17
+postgresql-client-18
 postgresql-client-common
 procps
 python3

--- a/heroku-26/installed-packages-amd64.txt
+++ b/heroku-26/installed-packages-amd64.txt
@@ -348,7 +348,7 @@ perl-modules-5.40
 pinentry-curses
 poppler-data
 poppler-utils
-postgresql-client-17
+postgresql-client-18
 postgresql-client-common
 procps
 readline-common

--- a/heroku-26/installed-packages-arm64.txt
+++ b/heroku-26/installed-packages-arm64.txt
@@ -348,7 +348,7 @@ perl-modules-5.40
 pinentry-curses
 poppler-data
 poppler-utils
-postgresql-client-17
+postgresql-client-18
 postgresql-client-common
 procps
 readline-common

--- a/heroku-26/setup.sh
+++ b/heroku-26/setup.sh
@@ -115,7 +115,7 @@ packages=(
   openssh-server # Used by Heroku Exec.
   patch
   poppler-utils # For Rails Active Storage Previews PDF support.
-  postgresql-client-17 # We need `psql` (and not just libpq) for Shield DB workflows (where connections are only possible from the dyno).
+  postgresql-client-18 # We need `psql` (and not just libpq) for Shield DB workflows (where connections are only possible from the dyno).
   rsync
   socat
   tar


### PR DESCRIPTION
Updates the Postgres client packages in all base images versions from v17 to v18.

See:
- https://www.postgresql.org/about/news/postgresql-18-released-3142/
- https://www.postgresql.org/docs/release/18.0/
- https://www.postgresql.org/docs/release/18.1/
- https://www.postgresql.org/docs/release/18.2/
- https://www.postgresql.org/docs/release/18.3/

GUS-W-21857354.