### PR TITLE
Explicitly install `libheif-plugin-libde265` on Heroku-24

### DIFF
--- a/heroku-24/setup.sh
+++ b/heroku-24/setup.sh
@@ -73,6 +73,7 @@ packages=(
   libgnutls-openssl27
   libgnutls30 # Used by the Ruby and PHP runtimes.
   libharfbuzz-icu0 # Used by FFmpeg in heroku-buildpack-activestorage-preview.
+  libheif-plugin-libde265 # Used to be a dependency of libheif1, now requiring explicitly to prevent package removal.
   liblttng-ust1 # Used by the .NET runtime.
   liblzf1 # Used by the PHP Redis extension.
   libmagickcore-6.q16-7-extra # Used by the PHP Imagick extension (using the `-extra` package for SVG support).


### PR DESCRIPTION
Since:
- It used to be installed as a `Depends` dependency of `libheif1`, however, has now been changed to only be a `Suggests` dependency, so doesn't get installed by default.
- We avoid removing packages from a base image once it's GAed to avoid breaking apps (given we rebase slugs onto newer images).

This fixes the failing CI on `main`:
https://github.com/heroku/base-images/actions/runs/25469130478/job/74728987477#step:5:13

See:
https://packages.ubuntu.com/noble/libheif1
https://packages.ubuntu.com/noble-updates/libheif1
https://packages.ubuntu.com/noble-updates/libheif-plugin-libde265

GUS-W-22450701.