### PR TITLE
Add CLI tool to manage stack image S3 bucket and manifests

### DIFF
--- a/bin/stacks-bucket/lib.sh
+++ b/bin/stacks-bucket/lib.sh
@@ -1,0 +1,203 @@
+# shellcheck shell=bash
+# Sourced by stacks-bucket scripts. Not executed directly.
+
+# Output helpers. All write to stderr except `print_ok`, which writes to stdout
+# because successful results (e.g. published release paths) are part of the
+# command's payload, not progress.
+print_err()  { printf '%s\n' "${*}" >&2; }
+print_warn() { printf '%s\n' "${*}" >&2; }
+print_info() { printf '%s\n' "${*}" >&2; }
+print_ok()   { printf '%s\n' "${*}"; }
+
+# Verify the complete setup for the stacks-bucket suite: required env vars
+# are set, required tools are installed, AWS auth works against the configured
+# bucket, and GPG signing works with the configured key. Prints a helpful
+# message and exits non-zero on the first failure.
+verify_setup() {
+	local required=(MANIFEST_BUCKET GPG_SIGNER GPG_PASSPHRASE IMAGE_DOWNLOAD_URL_PREFIX)
+	local missing=()
+	for var in "${required[@]}"; do
+		if [[ -z "${!var:-}" ]]; then
+			missing+=("${var}")
+		fi
+	done
+	if [[ "${#missing[@]}" -gt 0 ]]; then
+		print_err "Missing required environment variables: ${missing[*]}"
+		cat >&2 <<-EOF
+
+			Set them in your shell before running this command:
+
+			  export MANIFEST_BUCKET=<bucket name>
+			  export GPG_SIGNER=<key id or email of the signing key>
+			  export GPG_PASSPHRASE=<passphrase for that key>
+			  export IMAGE_DOWNLOAD_URL_PREFIX=<https url prefix consumers download images from>
+
+			For local testing against your own bucket, use whatever you bootstrapped with.
+			In CI, these come from repository secrets.
+		EOF
+		exit 1
+	fi
+
+	local tool
+	for tool in aws gpg yq; do
+		if ! command -v "${tool}" >/dev/null 2>&1; then
+			print_err "Missing required tool: ${tool}"
+			print_err "Install it before running this command."
+			exit 1
+		fi
+	done
+
+	if ! aws sts get-caller-identity >/dev/null 2>&1; then
+		print_err "AWS credentials are not configured or are invalid."
+		cat >&2 <<-EOF
+
+			Configure them with one of:
+			  aws configure
+			  export AWS_ACCESS_KEY_ID=... AWS_SECRET_ACCESS_KEY=...
+			  export AWS_PROFILE=<profile-name>
+		EOF
+		exit 1
+	fi
+
+	if ! aws s3api head-bucket --bucket "${MANIFEST_BUCKET}" >/dev/null 2>&1; then
+		print_err "Cannot access bucket: ${MANIFEST_BUCKET}"
+		print_err "Check the bucket name and that the configured AWS identity has access to it."
+		exit 1
+	fi
+
+	if ! echo test | gpg --batch --pinentry-mode loopback \
+		--passphrase-fd 3 --local-user "${GPG_SIGNER}" \
+		--clearsign >/dev/null 2>&1 3< <(printf '%s' "${GPG_PASSPHRASE}"); then
+		print_err "GPG signing test failed."
+		cat >&2 <<-EOF
+
+			Verify that:
+			  - The key for "${GPG_SIGNER}" is in your local keyring (gpg --list-secret-keys).
+			  - GPG_PASSPHRASE matches that key.
+		EOF
+		exit 1
+	fi
+}
+
+VALID_ENVS=(staging canary production)
+
+# Validate that the given string is a known environment name. Exits non-zero
+# with a friendly message otherwise.
+validate_deployment_env() {
+	local env="${1}" valid
+	for valid in "${VALID_ENVS[@]}"; do
+		if [[ "${env}" == "${valid}" ]]; then
+			return 0
+		fi
+	done
+	print_err "Invalid environment: '${env}'"
+	print_err "Valid environments: ${VALID_ENVS[*]}"
+	exit 1
+}
+
+# Validate that every name in <csv> is present (as `.name`) in the YAML array
+# at <yaml-file>. Exits non-zero with a friendly message listing unknowns.
+validate_stacks_in() {
+	local csv="${1}" yaml="${2}" context="${3}"
+	local unknown=()
+	mapfile -t known < <(yq -P '.[].name' "${yaml}")
+
+	IFS=',' read -ra requested <<<"${csv}"
+	for stack in "${requested[@]}"; do
+		stack="${stack// /}"
+		if [[ -z "${stack}" ]]; then
+			continue
+		fi
+		local found=0
+		for known_stack in "${known[@]}"; do
+			if [[ "${stack}" == "${known_stack}" ]]; then
+				found=1
+				break
+			fi
+		done
+		if [[ "${found}" -eq 0 ]]; then
+			unknown+=("${stack}")
+		fi
+	done
+
+	if [[ "${#unknown[@]}" -eq 0 ]]; then
+		return 0
+	fi
+	print_err "Unknown stacks for ${context}: ${unknown[*]}"
+	print_err "Known stacks: $(IFS=,; echo "${known[*]}")"
+	exit 1
+}
+
+get_live_manifest_path() {
+	case "${1}" in
+		staging)    echo "manifest-staging.yml" ;;
+		canary)     echo "manifest-canary.yml" ;;
+		production) echo "manifest.yml" ;;
+		*)
+			print_err "Unknown env: ${1}"
+			return 1
+			;;
+	esac
+}
+
+get_release_prefix() {
+	case "${1}" in
+		staging|canary|production) echo "releases/${1}/" ;;
+		*)
+			print_err "Unknown env: ${1}"
+			return 1
+			;;
+	esac
+}
+
+generate_release_manifest_path() {
+	local env="${1}"
+	printf '%s%s.yml.signed' "$(get_release_prefix "${env}")" "$(date -u +%Y-%m-%dT%H:%M:%SZ)"
+}
+
+build_s3_uri() {
+	echo "s3://${MANIFEST_BUCKET}/${1}"
+}
+
+# Download a manifest, verify its signature, and write the cleartext YAML.
+fetch_manifest() {
+	local env="${1}" output_file="${2}"
+	local signed_manifest_path
+	signed_manifest_path="$(get_live_manifest_path "${env}").signed"
+
+	aws s3 cp "$(build_s3_uri "${signed_manifest_path}")" - | gpg --decrypt --no-tty >"${output_file}"
+
+	if [[ ! -s "${output_file}" ]]; then
+		print_err "Empty manifest for ${env}"
+		return 1
+	fi
+}
+
+# Sign the given manifest and publish it as a new release for the given env.
+# Writes three S3 objects:
+#   - releases/<env>/<ts>.yml.signed  (new, immutable historical copy)
+#   - manifest-<env>.yml.signed       (overwrites the live signed manifest consumers fetch)
+#   - manifest-<env>.yml              (overwrites the live unsigned copy)
+publish_signed_manifest() {
+	local env="${1}" manifest_file="${2}"
+	local released_manifest_path live_manifest_path signed_manifest_file
+
+	released_manifest_path="$(generate_release_manifest_path "${env}")"
+	live_manifest_path="$(get_live_manifest_path "${env}")"
+	signed_manifest_file="$(mktemp)"
+
+	printf '%s' "${GPG_PASSPHRASE}" \
+		| gpg --batch --yes --pinentry-mode loopback --passphrase-fd 0 \
+			--local-user "${GPG_SIGNER}" --clearsign --output "${signed_manifest_file}" "${manifest_file}"
+
+	aws s3 cp "${signed_manifest_file}" "$(build_s3_uri "${released_manifest_path}")" \
+		--content-type text/plain >/dev/null
+
+	aws s3 cp "${signed_manifest_file}" "$(build_s3_uri "${live_manifest_path}.signed")" \
+		--content-type text/plain >/dev/null
+	aws s3 cp "${manifest_file}" "$(build_s3_uri "${live_manifest_path}")" \
+		--content-type text/plain >/dev/null
+
+	rm -f "${signed_manifest_file}"
+	print_ok "Published ${released_manifest_path}"
+}

--- a/bin/stacks-bucket/list-manifest-releases
+++ b/bin/stacks-bucket/list-manifest-releases
@@ -1,0 +1,61 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+# shellcheck source=lib.sh
+source "$(dirname "${0}")/lib.sh"
+
+exit_with_usage_message() {
+	cat >&2 <<-EOF
+		Usage: ${0} --env <env>
+
+		Lists releases for the given env, oldest first. Marks the current one.
+
+		Environments: ${VALID_ENVS[*]}
+	EOF
+	exit 1
+}
+
+env=""
+while [[ ${#} -gt 0 ]]; do
+	case "${1}" in
+		--env) env="${2}"; shift 2 ;;
+		*)
+			print_err "Unknown argument: ${1}"
+			exit_with_usage_message
+			;;
+	esac
+done
+
+if [[ -z "${env}" ]]; then
+	exit_with_usage_message
+fi
+
+validate_deployment_env "${env}"
+
+# These scripts rely on a set of common env vars, CLI tools, AWS access, and a GPG key.
+# Verify they're all in place before doing any real work.
+verify_setup
+
+mapfile -t release_timestamps < <(aws s3 ls "$(build_s3_uri "$(get_release_prefix "${env}")")" \
+	| awk '{print $4}' \
+	| grep -E '\.yml\.signed$' \
+	| sed -E 's/\.yml\.signed$//' \
+	| sort)
+
+if [[ "${#release_timestamps[@]}" -eq 0 ]]; then
+	print_err "No releases for ${env}"
+	exit 1
+fi
+
+current_release_ts="${release_timestamps[-1]}"
+
+echo "Current release for ${env}:"
+printf '  %s\n' "${current_release_ts}"
+
+if [[ "${#release_timestamps[@]}" -gt 1 ]]; then
+	echo "Previous releases for ${env}:"
+	# Iterate from second-newest down to oldest so the list reads top-down by recency.
+	for ((i=${#release_timestamps[@]}-2; i>=0; i--)); do
+		printf '  %s\n' "${release_timestamps[i]}"
+	done
+fi

--- a/bin/stacks-bucket/promote-stacks
+++ b/bin/stacks-bucket/promote-stacks
@@ -1,0 +1,95 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+# shellcheck source=lib.sh
+source "$(dirname "${0}")/lib.sh"
+
+exit_with_usage_message() {
+	cat >&2 <<-EOF
+		Usage: ${0} --from-env <env> --to-env <env> [--stacks <csv>] [--dry-run]
+
+		Environments: ${VALID_ENVS[*]}
+		Stacks:  comma-separated stack names (e.g. heroku-24,heroku-24-build).
+		         If omitted, all stacks from <from-env> are promoted.
+		Dry-run: Print what would change without publishing.
+	EOF
+	exit 1
+}
+
+from_env=""
+to_env=""
+stacks=""
+do_dry_run=0
+while [[ ${#} -gt 0 ]]; do
+	case "${1}" in
+		--from-env) from_env="${2}"; shift 2 ;;
+		--to-env)   to_env="${2}";   shift 2 ;;
+		--stacks)   stacks="${2}";   shift 2 ;;
+		--dry-run)  do_dry_run=1;    shift ;;
+		*)
+			print_err "Unknown argument: ${1}"
+			exit_with_usage_message
+			;;
+	esac
+done
+
+if [[ -z "${from_env}" || -z "${to_env}" ]]; then
+	exit_with_usage_message
+fi
+
+validate_deployment_env "${from_env}"
+validate_deployment_env "${to_env}"
+
+# These scripts rely on a set of common env vars, CLI tools, AWS access, and a GPG key.
+# Verify they're all in place before doing any real work.
+verify_setup
+
+WORKDIR="$(mktemp -d)"
+trap 'rm -rf "${WORKDIR}"' EXIT
+
+from_manifest_file="${WORKDIR}/${from_env}.yml"
+to_manifest_file="${WORKDIR}/${to_env}.yml"
+modified_manifest_file="${WORKDIR}/${to_env}-modified.yml"
+
+print_info "Fetching manifest for ${from_env}"
+fetch_manifest "${from_env}" "${from_manifest_file}"
+print_info "Fetching manifest for ${to_env}"
+fetch_manifest "${to_env}" "${to_manifest_file}"
+
+if [[ -n "${stacks}" ]]; then
+	validate_stacks_in "${stacks}" "${from_manifest_file}" "${from_env}"
+fi
+
+if [[ -z "${stacks}" ]]; then
+	print_info "Copying ${from_env} manifest as the new ${to_env} manifest"
+	cp "${from_manifest_file}" "${modified_manifest_file}"
+else
+	print_info "Promoting ${stacks} from ${from_env} to ${to_env}"
+	# Drop the selected stacks from the to-manifest, append them from the from-manifest.
+	# yq strips the YAML document marker when a filter rewrites the doc, so we prepend it ourselves.
+	{
+		echo '---'
+		from_manifest_file="${from_manifest_file}" to_manifest_file="${to_manifest_file}" stacks="${stacks}" \
+			yq -P --null-input '
+				(load(strenv(to_manifest_file)) | map(select(.name as $name | (strenv(stacks) | split(",")) | contains([$name]) | not)))
+				+ (load(strenv(from_manifest_file)) | map(select(.name as $name | (strenv(stacks) | split(",")) | contains([$name]))))
+				| sort_by(.name)
+			'
+	} >"${modified_manifest_file}"
+fi
+
+print_info "Diffing the manifests"
+diff -u "${to_manifest_file}" "${modified_manifest_file}" || true
+
+if diff -q "${to_manifest_file}" "${modified_manifest_file}" >/dev/null; then
+	print_warn "No effective change; nothing to do."
+	exit 0
+fi
+
+if [[ "${do_dry_run}" -eq 1 ]]; then
+	print_warn "Dry-run: not publishing."
+	exit 0
+fi
+
+print_info "Publishing to ${to_env}"
+publish_signed_manifest "${to_env}" "${modified_manifest_file}"

--- a/bin/stacks-bucket/rollback-stacks
+++ b/bin/stacks-bucket/rollback-stacks
@@ -1,0 +1,216 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+# shellcheck source=lib.sh
+source "$(dirname "${0}")/lib.sh"
+
+exit_with_usage_message() {
+	cat >&2 <<-EOF
+		Usage: ${0} --env <env> [--stacks <csv>] [--at <date-or-timestamp>] [--dry-run]
+
+		Environments: ${VALID_ENVS[*]}
+		Stacks:       comma-separated stack names. If omitted, the whole manifest is rolled back.
+		At:           ISO date (2026-05-19) or timestamp (2026-05-19T14:00:00Z).
+		              Resolves to the most recent release on or before that point.
+		              If omitted, resolves to the previous release (one before current).
+		Dry-run:      Print what would change without publishing.
+
+		To list available releases for an env, use list-manifest-releases.
+	EOF
+	exit 1
+}
+
+env=""
+stacks=""
+at=""
+do_dry_run=0
+while [[ ${#} -gt 0 ]]; do
+	case "${1}" in
+		--env)     env="${2}";    shift 2 ;;
+		--stacks)  stacks="${2}"; shift 2 ;;
+		--at)      at="${2}";     shift 2 ;;
+		--dry-run) do_dry_run=1;  shift ;;
+		*)
+			print_err "Unknown argument: ${1}"
+			exit_with_usage_message
+			;;
+	esac
+done
+if [[ -z "${env}" ]]; then
+	exit_with_usage_message
+fi
+validate_deployment_env "${env}"
+
+# These scripts rely on a set of common env vars, CLI tools, AWS access, and a GPG key.
+# Verify they're all in place before doing any real work.
+verify_setup
+
+WORKDIR="$(mktemp -d)"
+trap 'rm -rf "${WORKDIR}"' EXIT
+
+# Returns release timestamps (no path, no extension) for the env, oldest first.
+list_release_timestamps() {
+	aws s3 ls "$(build_s3_uri "$(get_release_prefix "${env}")")" \
+		| awk '{print $4}' \
+		| grep -E '\.yml\.signed$' \
+		| sed -E 's/\.yml\.signed$//' \
+		| sort
+}
+
+# Download a release file (by timestamp) and write its decrypted YAML.
+fetch_release_manifest() {
+	local release_ts="${1}" output_file="${2}"
+	aws s3 cp "$(build_s3_uri "$(get_release_prefix "${env}")${release_ts}.yml.signed")" - \
+		| gpg --decrypt --no-tty >"${output_file}"
+	if [[ ! -s "${output_file}" ]]; then
+		print_err "Empty release for ${release_ts}"
+		return 1
+	fi
+}
+
+mapfile -t release_timestamps < <(list_release_timestamps)
+if [[ "${#release_timestamps[@]}" -eq 0 ]]; then
+	print_err "No releases for ${env}"
+	exit 1
+fi
+
+current_release_ts="${release_timestamps[-1]}"
+print_info "Current release: ${current_release_ts}"
+
+# Filter candidates to "everything except current."
+candidate_release_timestamps=("${release_timestamps[@]:0:${#release_timestamps[@]}-1}")
+if [[ "${#candidate_release_timestamps[@]}" -eq 0 ]]; then
+	print_err "Only one release exists for ${env}; nothing to roll back to."
+	exit 1
+fi
+
+# If --at, narrow candidates to those <= that point in time.
+# A bare date (YYYY-MM-DD) is treated as end-of-day UTC.
+if [[ -n "${at}" ]]; then
+	if [[ "${at}" =~ ^[0-9]{4}-[0-9]{2}-[0-9]{2}$ ]]; then
+		at_cmp="${at}T23:59:59Z"
+	else
+		at_cmp="${at}"
+	fi
+	filtered_release_timestamps=()
+	for release_ts in "${candidate_release_timestamps[@]}"; do
+		if [[ "${release_ts}" < "${at_cmp}" || "${release_ts}" == "${at_cmp}" ]]; then
+			filtered_release_timestamps+=("${release_ts}")
+		fi
+	done
+	candidate_release_timestamps=("${filtered_release_timestamps[@]}")
+	if [[ "${#candidate_release_timestamps[@]}" -eq 0 ]]; then
+		print_err "No release on or before ${at}"
+		exit 1
+	fi
+fi
+
+# Resolve current YAML once for diffs and per-stack lookups.
+current_manifest_file="${WORKDIR}/${env}-current.yml"
+fetch_release_manifest "${current_release_ts}" "${current_manifest_file}"
+
+if [[ -n "${stacks}" ]]; then
+	validate_stacks_in "${stacks}" "${current_manifest_file}" "${env}"
+fi
+
+if [[ -z "${stacks}" ]]; then
+	# Whole-env rollback: the target is the most recent candidate.
+	target_release_ts="${candidate_release_timestamps[-1]}"
+	print_info "Target release: ${target_release_ts}"
+	target_manifest_file="${WORKDIR}/${env}-target.yml"
+	fetch_release_manifest "${target_release_ts}" "${target_manifest_file}"
+
+	print_info "Diff (- current, + target):"
+	diff -u "${current_manifest_file}" "${target_manifest_file}" || true
+
+	if diff -q "${current_manifest_file}" "${target_manifest_file}" >/dev/null; then
+		print_warn "Current and target are identical; nothing to do."
+		exit 0
+	fi
+
+	if [[ "${do_dry_run}" -eq 1 ]]; then
+		print_warn "Dry-run: not publishing."
+		exit 0
+	fi
+
+	publish_signed_manifest "${env}" "${target_manifest_file}"
+	exit 0
+fi
+
+# Per-stack rollback: for each named stack, find the most recent candidate
+# release where its entry differs from current.
+IFS=',' read -ra stack_list <<<"${stacks}"
+declare -A target_release_for_stack
+missing=()
+
+for stack in "${stack_list[@]}"; do
+	stack="${stack// /}"
+	if [[ -z "${stack}" ]]; then
+		continue
+	fi
+	found_release_ts=""
+	for ((i=${#candidate_release_timestamps[@]}-1; i>=0; i--)); do
+		release_ts="${candidate_release_timestamps[i]}"
+		release_manifest_file="${WORKDIR}/${env}-release-${release_ts}.yml"
+		if [[ ! -s "${release_manifest_file}" ]]; then
+			fetch_release_manifest "${release_ts}" "${release_manifest_file}"
+		fi
+		current_entry="$(yq -o=json ".[] | select(.name == \"${stack}\")" "${current_manifest_file}")"
+		release_entry="$(yq -o=json ".[] | select(.name == \"${stack}\")" "${release_manifest_file}")"
+		if [[ -z "${release_entry}" ]]; then
+			continue
+		fi
+		if [[ "${current_entry}" != "${release_entry}" ]]; then
+			found_release_ts="${release_ts}"
+			break
+		fi
+	done
+	if [[ -z "${found_release_ts}" ]]; then
+		missing+=("${stack}")
+		continue
+	fi
+	target_release_for_stack["${stack}"]="${found_release_ts}"
+	print_info "  ${stack} -> ${found_release_ts}"
+done
+
+if [[ "${#missing[@]}" -gt 0 ]]; then
+	print_err "No previous version in ${env} for: ${missing[*]}"
+	exit 1
+fi
+
+# Build a new manifest = current + selected substitutions.
+# Start from current, then for each rolled-back stack swap its entry with the
+# version from the chosen release. yq strips the document marker when a filter
+# rewrites the doc, so we prepend it ourselves on each pass.
+modified_manifest_file="${WORKDIR}/${env}-modified.yml"
+cp "${current_manifest_file}" "${modified_manifest_file}"
+for stack in "${!target_release_for_stack[@]}"; do
+	release_ts="${target_release_for_stack[${stack}]}"
+	release_manifest_file="${WORKDIR}/${env}-release-${release_ts}.yml"
+	next_manifest_file="${WORKDIR}/${env}-modified-next.yml"
+	{
+		echo '---'
+		stack="${stack}" release_manifest_file="${release_manifest_file}" modified_manifest_file="${modified_manifest_file}" \
+			yq -P --null-input '
+				load(strenv(modified_manifest_file))
+				| (.[] | select(.name == strenv(stack))) |=
+					(load(strenv(release_manifest_file)) | .[] | select(.name == strenv(stack)))
+			'
+	} >"${next_manifest_file}"
+	mv "${next_manifest_file}" "${modified_manifest_file}"
+done
+
+print_info "Diff (- current, + new):"
+diff -u "${current_manifest_file}" "${modified_manifest_file}" || true
+
+if diff -q "${current_manifest_file}" "${modified_manifest_file}" >/dev/null; then
+	print_warn "No effective change; nothing to do."
+	exit 0
+fi
+
+if [[ "${do_dry_run}" -eq 1 ]]; then
+	print_warn "Dry-run: not publishing."
+	exit 0
+fi
+
+publish_signed_manifest "${env}" "${modified_manifest_file}"

--- a/bin/stacks-bucket/show-manifest
+++ b/bin/stacks-bucket/show-manifest
@@ -1,0 +1,82 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+# shellcheck source=lib.sh
+source "$(dirname "${0}")/lib.sh"
+
+exit_with_usage_message() {
+	cat >&2 <<-EOF
+		Usage:
+		  ${0} --env <env>                          Print the current live manifest.
+		  ${0} --env <env> --release <timestamp>    Print a specific release.
+		  ${0} --env <env> --at <date-or-ts>        Print the release that was live at that point.
+
+		Environments: ${VALID_ENVS[*]}
+	EOF
+	exit 1
+}
+
+env=""
+release=""
+at=""
+while [[ ${#} -gt 0 ]]; do
+	case "${1}" in
+		--env)     env="${2}";     shift 2 ;;
+		--release) release="${2}"; shift 2 ;;
+		--at)      at="${2}";      shift 2 ;;
+		*)
+			print_err "Unknown argument: ${1}"
+			exit_with_usage_message
+			;;
+	esac
+done
+
+if [[ -z "${env}" ]]; then
+	exit_with_usage_message
+fi
+
+validate_deployment_env "${env}"
+
+if [[ -n "${release}" && -n "${at}" ]]; then
+	print_err "--release and --at are mutually exclusive"
+	exit 1
+fi
+
+# These scripts rely on a set of common env vars, CLI tools, AWS access, and a GPG key.
+# Verify they're all in place before doing any real work.
+verify_setup
+
+WORKDIR="$(mktemp -d)"
+trap 'rm -rf "${WORKDIR}"' EXIT
+output_file="${WORKDIR}/${env}-manifest.yml"
+
+if [[ -n "${release}" ]]; then
+	aws s3 cp "$(build_s3_uri "$(get_release_prefix "${env}")${release}.yml.signed")" - \
+		| gpg --decrypt --no-tty >"${output_file}"
+elif [[ -n "${at}" ]]; then
+	if [[ "${at}" =~ ^[0-9]{4}-[0-9]{2}-[0-9]{2}$ ]]; then
+		at_cmp="${at}T23:59:59Z"
+	else
+		at_cmp="${at}"
+	fi
+	target_release_ts=""
+	while IFS= read -r release_ts; do
+		if [[ "${release_ts}" < "${at_cmp}" || "${release_ts}" == "${at_cmp}" ]]; then
+			target_release_ts="${release_ts}"
+		fi
+	done < <(aws s3 ls "$(build_s3_uri "$(get_release_prefix "${env}")")" \
+		| awk '{print $4}' \
+		| grep -E '\.yml\.signed$' \
+		| sed -E 's/\.yml\.signed$//' \
+		| sort)
+	if [[ -z "${target_release_ts}" ]]; then
+		print_err "No release on or before ${at}"
+		exit 1
+	fi
+	aws s3 cp "$(build_s3_uri "$(get_release_prefix "${env}")${target_release_ts}.yml.signed")" - \
+		| gpg --decrypt --no-tty >"${output_file}"
+else
+	fetch_manifest "${env}" "${output_file}"
+fi
+
+cat "${output_file}"

--- a/bin/stacks-bucket/upload-image
+++ b/bin/stacks-bucket/upload-image
@@ -1,0 +1,110 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+# shellcheck source=lib.sh
+source "$(dirname "${0}")/lib.sh"
+
+exit_with_usage_message() {
+	cat >&2 <<-EOF
+		Usage: ${0} --env staging --stack <name> --version <ver> --git-ref <sha> --file <path>
+
+		Uploads a single image's gz tarball to s3://\$MANIFEST_BUCKET/images/, computes
+		its sha256, builds a manifest entry, replaces the existing entry for that stack
+		in the staging manifest (or inserts if absent), and publishes a new release.
+
+		Only --env staging is allowed. Promotions to canary/production go via
+		promote-stacks, rollbacks via rollback-stacks.
+	EOF
+	exit 1
+}
+
+env=""
+stack_name=""
+version=""
+git_ref=""
+file=""
+while [[ ${#} -gt 0 ]]; do
+	case "${1}" in
+		--env)     env="${2}";        shift 2 ;;
+		--stack)   stack_name="${2}"; shift 2 ;;
+		--version) version="${2}";    shift 2 ;;
+		--git-ref) git_ref="${2}";    shift 2 ;;
+		--file)    file="${2}";       shift 2 ;;
+		*)
+			print_err "Unknown argument: ${1}"
+			exit_with_usage_message
+			;;
+	esac
+done
+
+# Uploading images is only allowed to staging. We keep it as an explicit argument to make
+# it more explicit, but also allowing manual emergency uploads by removing this check here.
+if [[ "${env}" != "staging" ]]; then
+	print_err "--env must be staging"
+	exit_with_usage_message
+fi
+
+if [[ -z "${stack_name}" || -z "${version}" || -z "${git_ref}" || -z "${file}" ]]; then
+	exit_with_usage_message
+fi
+
+if [[ ! -f "${file}" ]]; then
+	print_err "File does not exist: ${file}"
+	exit 1
+fi
+
+# These scripts rely on a set of common env vars, CLI tools, AWS access, and a GPG key.
+# Verify they're all in place before doing any real work.
+verify_setup
+
+WORKDIR="$(mktemp -d)"
+trap 'rm -rf "${WORKDIR}"' EXIT
+
+image_filename="${stack_name}-${version}.img.gz"
+image_sha256="$(shasum -a 256 "${file}" | awk '{print $1}')"
+# IMAGE_DOWNLOAD_URL_PREFIX is the public https prefix consumers fetch images from.
+# It's distinct from MANIFEST_BUCKET (the write target) so we can front the bucket
+# with a CDN or use a different host without changing where we upload.
+image_url="${IMAGE_DOWNLOAD_URL_PREFIX%/}/${image_filename}"
+
+current_manifest_file="${WORKDIR}/${env}-current.yml"
+modified_manifest_file="${WORKDIR}/${env}-modified.yml"
+
+print_info "Fetching manifest for ${env}"
+fetch_manifest "${env}" "${current_manifest_file}"
+
+print_info "Updating ${stack_name} in ${env} manifest"
+
+# Drop any existing entry with the same stack name, then append the new one and sort.
+# yq reads values via strenv(); the env vars are scoped to this single command.
+# yq strips the YAML document marker when a filter rewrites the doc, so we prepend it ourselves.
+{
+	echo '---'
+	stack_name="${stack_name}" version="${version}" git_ref="${git_ref}" image_url="${image_url}" image_sha256="${image_sha256}" \
+		yq -P '
+			map(select(.name != strenv(stack_name)))
+			+ [{
+				"name": strenv(stack_name),
+				"version": strenv(version),
+				"git_ref": strenv(git_ref),
+				"url": strenv(image_url),
+				"sha256": strenv(image_sha256),
+				"primary": true,
+			}]
+			| sort_by(.name)
+		' "${current_manifest_file}"
+} >"${modified_manifest_file}"
+
+print_info "Diffing the manifests"
+diff -u "${current_manifest_file}" "${modified_manifest_file}" || true
+
+if diff -q "${current_manifest_file}" "${modified_manifest_file}" >/dev/null; then
+	print_warn "No effective change, stopping"
+	exit 0
+fi
+
+print_info "Uploading ${image_filename}"
+aws s3 cp "${file}" "s3://${MANIFEST_BUCKET}/images/${image_filename}" \
+	--content-type application/gzip >/dev/null
+
+publish_signed_manifest "${env}" "${modified_manifest_file}"


### PR DESCRIPTION
Part of the Cheverny replacement, and the second of two chunks — the other one is #391, which covers the changelog and DevCenter package report generation. This PR covers the bucket and manifest management side.

Adds a suite of bash CLI tools under `bin/stacks-bucket/` that manage the S3 bucket holding stack images and the signed manifest releases consumers resolve against. The tools cover uploading images, promoting them into a new manifest release, rolling back to a previous release, listing releases, and inspecting an individual manifest. Manifests are GPG-signed.

The GHA glue that wires these up in CI will be added in a follow-up PR.